### PR TITLE
Enable AWS ENV VAR key auth

### DIFF
--- a/pkg/provider/aws/aws.go
+++ b/pkg/provider/aws/aws.go
@@ -83,7 +83,11 @@ type Client struct {
 
 func New(log *logger.FunLogger, env v1alpha1.Environment, cacheFile string) (*Client, error) {
 	// Create an AWS session and configure the EC2 client
-	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(env.Spec.Region))
+	region := env.Spec.Region
+	if envRegion := os.Getenv("AWS_REGION"); envRegion != "" {
+		region = envRegion
+	}
+	cfg, err := config.LoadDefaultConfig(context.TODO(), config.WithRegion(region))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Before this PR, this project was only taking into account the region in the config file.
This PR fixes that by moving to (in descending order) :

- ENV AWS_REGION
- Config file

The aws config file is not taken into account by design. The idea is to be used by a GitHub action or manual testing.