### PR TITLE
Remove dependabot rule for release-0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,22 +18,6 @@ updates:
         exclude-patterns:
         - k8s.io/klog/*
 
-  - package-ecosystem: "gomod"
-    target-branch: release-0.1
-    directory: "/"
-    schedule:
-      interval: "weekly"
-      day: "sunday"
-    labels:
-    - dependencies
-    - maintenance
-    groups:
-      k8sio:
-        patterns:
-        - k8s.io/*
-        exclude-patterns:
-        - k8s.io/klog/*
-
   - package-ecosystem: "github-actions"
     target-branch: main
     directory: "/"


### PR DESCRIPTION
We remove the dependabot rule from the release-0.1 branch.

This project is still in early development and the overhead of dependency management of a stable release branch is not worth the benefits.