### PR TITLE
Update EC2 instance tags when running in CI mode

### DIFF
--- a/cmd/action/ci/ci.go
+++ b/cmd/action/ci/ci.go
@@ -23,6 +23,8 @@ import (
 
 	"github.com/NVIDIA/holodeck/api/holodeck/v1alpha1"
 	"github.com/NVIDIA/holodeck/internal/logger"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+	"github.com/aws/aws-sdk-go/aws"
 )
 
 const (
@@ -77,4 +79,24 @@ func generateUID() string {
 	}
 
 	return string(b)
+}
+
+// instanceTags returns the tags to be applied to the EC2 instance
+// based on the GitHub environment variables https://docs.github.com/en/actions/learn-github-actions/variables
+func instanceTags() []types.Tag {
+	envs := []string{
+		"GITHUB_JOB",
+		"GITHUB_REPOSITORY",
+		"GITHUB_ACTOR",
+		"GITHUB_SHA",
+	}
+	var tags []types.Tag
+	for _, env := range envs {
+		tag := types.Tag{
+			Key:   aws.String(env),
+			Value: aws.String(os.Getenv(env)),
+		}
+		tags = append(tags, tag)
+	}
+	return tags
 }

--- a/pkg/provider/aws/update.go
+++ b/pkg/provider/aws/update.go
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package aws
+
+import (
+	"context"
+
+	"github.com/aws/aws-sdk-go-v2/service/ec2"
+	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
+)
+
+// Update updates an AWS resources tags
+func (a *Client) UpdateResourcesTags(tags []types.Tag, resources ...string) error {
+	a.log.Wg.Add(1)
+	go a.log.Loading("Tagging AWS resources...")
+
+	createTagsIn := &ec2.CreateTagsInput{
+		Resources: resources,
+		Tags:      tags,
+	}
+
+	_, err := a.ec2.CreateTags(context.Background(), createTagsIn)
+	if err != nil {
+		a.fail()
+		return err
+	}
+	a.done()
+
+	return nil
+}


### PR DESCRIPTION
Now that multiple projects will be using Holodeck from GitHub actions, is convenient to tag EC2 instances with information for debugging purposes 