### PR TITLE
fix intermittent calico failures during k8s-bootstrap

### DIFF
--- a/pkg/provisioner/templates/kubernetes.go
+++ b/pkg/provisioner/templates/kubernetes.go
@@ -95,8 +95,10 @@ export KUBECONFIG="${HOME}/.kube/config"
 
 # Install Calico
 # based on https://docs.tigera.io/calico/latest/getting-started/kubernetes/quickstart
-with_retry 3 10s kubectl --kubeconfig $KUBECONFIG create -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/tigera-operator.yaml
-with_retry 3 10s kubectl --kubeconfig $KUBECONFIG create -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/custom-resources.yaml
+with_retry 3 10s kubectl --kubeconfig $KUBECONFIG apply -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/tigera-operator.yaml
+# Calico CRDs created. Now we sleep for 10s to ensure they are fully registered in the K8s etcd
+sleep 10s
+with_retry 3 10s kubectl --kubeconfig $KUBECONFIG apply -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/custom-resources.yaml
 # Make single-node cluster schedulable
 kubectl taint nodes --all node-role.kubernetes.io/control-plane:NoSchedule-
 kubectl label node --all node-role.kubernetes.io/worker=


### PR DESCRIPTION
This PR hopefully fixes some of the flakes we have observed when deploying calico on a newly created K8s cluster.

The root cause of the failure is that the `kubectl --kubeconfig $KUBECONFIG create -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/custom-resources.yaml` command fails as the cluster doesn't immediately recognise one of the custom resource kinds (defined by the CRD created in the previous step) as there seems to be some delay in CRD creation going through after issuing the kubectl create command of the same. This failure prompts a retry which ultimately fails as it also retries creating custom resources which were already created successfully in the first attempt.

This PR applies a two-fold fix
i) Run `kubectl apply` instead of `kubectl create` as it is idempotent and declarative
ii) Sleep 10s after the Calico CRDs are created so that the new kinds are fully registered in the cluster etcd 