### PR TITLE
Set containerd as default runtime when not specified

### DIFF
--- a/pkg/provisioner/templates/container-toolkit.go
+++ b/pkg/provisioner/templates/container-toolkit.go
@@ -46,8 +46,12 @@ type ContainerToolkit struct {
 }
 
 func NewContainerToolkit(env v1alpha1.Environment) *ContainerToolkit {
+	runtime := string(env.Spec.ContainerRuntime.Name)
+	if runtime == "" {
+		runtime = "containerd"
+	}
 	return &ContainerToolkit{
-		ContainerRuntime: string(env.Spec.ContainerRuntime.Name),
+		ContainerRuntime: runtime,
 	}
 }
 


### PR DESCRIPTION
Fixes #19 
When the `.Spec.ContainerRuntime.Name`  is not specified, sets `containerd` as runtime