### PR TITLE
use kubectl create to provision calico CRDs

### DIFF
--- a/pkg/provisioner/templates/kubernetes.go
+++ b/pkg/provisioner/templates/kubernetes.go
@@ -95,7 +95,7 @@ export KUBECONFIG="${HOME}/.kube/config"
 
 # Install Calico
 # based on https://docs.tigera.io/calico/latest/getting-started/kubernetes/quickstart
-with_retry 3 10s kubectl --kubeconfig $KUBECONFIG apply -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/tigera-operator.yaml
+with_retry 3 10s kubectl --kubeconfig $KUBECONFIG create -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/tigera-operator.yaml
 # Calico CRDs created. Now we sleep for 10s to ensure they are fully registered in the K8s etcd
 sleep 10s
 with_retry 3 10s kubectl --kubeconfig $KUBECONFIG apply -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/custom-resources.yaml


### PR DESCRIPTION
This PR fixes the regression introduced by PR https://github.com/NVIDIA/holodeck/pull/175

I initially switched the kubectl commands from apply to create as apply was idempotent and safer when running commands in a retry loop. However, the `Installation CRD` of the Calico Operator is so large that (1.1 MB) that it exceeds the kubernetes annotation size of 262144 bytes (every resource created via `kubectl apply` has the `kubectl.kubernetes.io/last-applied-configuration` annotation added to it)

Since the  holodeck e2e flakes happen when executing the following command in a retry loop, it should suffice to just `kubectl apply` the calico `custom-resources.yaml` file

```
with_retry 3 10s kubectl --kubeconfig $KUBECONFIG apply -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/custom-resources.yaml
```