### PR TITLE
Enable containerd 2.0+ installation

### DIFF
--- a/examples/aws_kubeadm.yaml
+++ b/examples/aws_kubeadm.yaml
@@ -1,0 +1,27 @@
+apiVersion: holodeck.nvidia.com/v1alpha1
+kind: Environment
+metadata:
+  name: aws_kubeadm_example
+  description: "end-to-end test infrastructure"
+spec:
+  provider: aws
+  auth:
+    keyName: <your key name here>
+    privateKey: <your key path here>
+  instance:
+    type: g4dn.xlarge
+    region: us-west-1
+    ingressIpRanges:
+    - <youip/32>
+    image:
+      architecture: amd64
+  nvidiaDriver:
+    install: true
+  nvidiaContainerToolkit:
+    install: true
+  containerRuntime:
+    install: true
+    name: containerd
+  kubernetes:
+    install: true
+    installer: kubeadm

--- a/pkg/provisioner/templates/container-toolkit.go
+++ b/pkg/provisioner/templates/container-toolkit.go
@@ -34,7 +34,7 @@ curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dear
   && \
     sudo apt-get update
 
-sudo apt-get install -y nvidia-container-toolkit
+install_packages_with_retry nvidia-container-toolkit
 
 # Configure container runtime
 sudo nvidia-ctk runtime configure --runtime={{.ContainerRuntime}} --set-as-default --enable-cdi={{.EnableCDI}}

--- a/pkg/provisioner/templates/containerd.go
+++ b/pkg/provisioner/templates/containerd.go
@@ -28,33 +28,293 @@ import (
 const containerdTemplate = `
 : ${CONTAINERD_VERSION:={{.Version}}}
 
+# Check system requirements
+echo "Checking system requirements..."
+
+# Check for systemd
+if ! command -v systemctl &> /dev/null; then
+    echo "Error: systemd is required but not installed"
+    exit 1
+fi
+
+# Check and load required kernel modules
+echo "Checking and loading required kernel modules..."
+REQUIRED_MODULES="overlay br_netfilter"
+for module in $REQUIRED_MODULES; do
+    if ! lsmod | grep -q "^${module}"; then
+        echo "Loading ${module} module..."
+        if ! sudo modprobe ${module}; then
+            echo "Error: Failed to load ${module} module"
+            exit 1
+        fi
+    fi
+done
+
+# Ensure modules are loaded at boot
+for module in $REQUIRED_MODULES; do
+    if [ ! -f "/etc/modules-load.d/${module}.conf" ]; then
+        echo "${module}" | sudo tee "/etc/modules-load.d/${module}.conf" > /dev/null
+    fi
+done
+
+# Check and configure sysctl settings
+echo "Configuring sysctl settings..."
+SYSCTL_SETTINGS=(
+    "net.bridge.bridge-nf-call-iptables=1"
+    "net.bridge.bridge-nf-call-ip6tables=1"
+    "net.ipv4.ip_forward=1"
+)
+
+for setting in "${SYSCTL_SETTINGS[@]}"; do
+    key=$(echo $setting | cut -d= -f1)
+    value=$(echo $setting | cut -d= -f2)
+    if [ "$(sudo sysctl -n $key)" != "$value" ]; then
+        echo "Setting $key to $value"
+        sudo sysctl -w $key=$value
+        echo "$key=$value" | sudo tee -a /etc/sysctl.conf > /dev/null
+    fi
+done
+
+# Apply sysctl settings
+sudo sysctl --system
+
+# Check for required commands
+REQUIRED_COMMANDS="curl tar systemctl"
+for cmd in $REQUIRED_COMMANDS; do
+    if ! command -v $cmd &> /dev/null; then
+        echo "Error: Required command '$cmd' not found"
+        exit 1
+    fi
+done
+
 # Install required packages
+echo "Installing required packages..."
 with_retry 3 10s sudo apt-get update
 install_packages_with_retry ca-certificates curl gnupg -y
 sudo install -m 0755 -d /etc/apt/keyrings
-curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /etc/apt/keyrings/docker.gpg
-sudo chmod a+r /etc/apt/keyrings/docker.gpg
 
-# Add the repository to Apt sources:
-echo \
-  "deb [arch="$(dpkg --print-architecture)" signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu \
-  "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
-  sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-  with_retry 3 10s sudo apt-get update
+# Check if CONTAINERD_VERSION is empty, if so fetch the latest stable version
+if [ -z "$CONTAINERD_VERSION" ]; then
+    echo "Fetching latest stable containerd version..."
+    CONTAINERD_VERSION=$(curl -fsSL https://api.github.com/repos/containerd/containerd/releases/latest | grep '"tag_name":' | cut -d '"' -f 4 | sed 's/v//')
 
-# Install containerd
-install_packages_with_retry containerd.io=${CONTAINERD_VERSION}-1
+    if [ -z "$CONTAINERD_VERSION" ]; then
+        echo "Failed to fetch latest Containerd version. Exiting."
+        exit 1
+    fi
+fi
+echo "Using containerd version: $CONTAINERD_VERSION"
 
-# Configure containerd and start service
-mkdir -p /etc/containerd
-containerd config default | sudo tee /etc/containerd/config.toml
-# Set systemd as the cgroup driver 
-# see https://kubernetes.io/docs/setup/production-environment/container-runtimes/#containerd
-sudo sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/g' /etc/containerd/config.toml
+# Determine major version for configuration
+MAJOR_VERSION=$(echo $CONTAINERD_VERSION | cut -d. -f1)
 
-# restart containerd
-sudo systemctl restart containerd
-sudo systemctl enable containerd
+# Check architecture
+ARCH=$(uname -m)
+if [[ "$ARCH" == "x86_64" ]]; then
+    ARCH="amd64"
+elif [[ "$ARCH" == "aarch64" ]]; then
+    ARCH="arm64"
+else
+    echo "Error: Unsupported architecture: $ARCH"
+    exit 1
+fi
+
+CONTAINERD_TAR="containerd-${CONTAINERD_VERSION}-linux-${ARCH}.tar.gz"
+CONTAINERD_URL="https://github.com/containerd/containerd/releases/download/v${CONTAINERD_VERSION}/${CONTAINERD_TAR}"
+CONTAINERD_SHA256_URL="${CONTAINERD_URL}.sha256sum"
+
+echo "Downloading and extracting containerd ${CONTAINERD_VERSION} from: $CONTAINERD_URL"
+
+# Create temporary directory for downloads
+TMP_DIR=$(mktemp -d)
+cd $TMP_DIR
+
+# Download containerd tarball and checksum
+if ! curl -fsSL -o ${CONTAINERD_TAR} ${CONTAINERD_URL}; then
+    echo "Error: Failed to download containerd tarball"
+    exit 1
+fi
+
+if ! curl -fsSL -o containerd_SHA256SUMS ${CONTAINERD_SHA256_URL}; then
+    echo "Error: Failed to download containerd checksum"
+    exit 1
+fi
+
+# Verify SHA256 checksum
+EXPECTED_CHECKSUM=$(cat containerd_SHA256SUMS | awk '{print $1}')
+ACTUAL_CHECKSUM=$(sha256sum ${CONTAINERD_TAR} | awk '{print $1}')
+
+if [ "$EXPECTED_CHECKSUM" != "$ACTUAL_CHECKSUM" ]; then
+    echo "Error: Checksum verification failed for containerd"
+    echo "Expected: $EXPECTED_CHECKSUM"
+    echo "Actual:   $ACTUAL_CHECKSUM"
+    exit 1
+fi
+
+# Stream directly into tar to avoid saving the archive
+if ! cat ${CONTAINERD_TAR} | sudo tar Cxzvf /usr/local -; then
+    echo "Error: Failed to extract containerd tarball"
+    exit 1
+fi
+
+# Cleanup
+cd - > /dev/null
+rm -rf $TMP_DIR
+
+echo "Containerd ${CONTAINERD_VERSION} installed successfully."
+
+# Fetch latest stable RUNC version from GitHub
+echo "Fetching latest stable runc version..."
+RUNC_VERSION=$(curl -fsSL https://api.github.com/repos/opencontainers/runc/releases/latest | grep '"tag_name":' | cut -d '"' -f 4 | sed 's/v//')
+
+if [ -z "$RUNC_VERSION" ]; then
+    echo "Failed to fetch latest RUNC version. Using default version."
+    RUNC_VERSION="1.2.6"
+fi
+
+RUNC_URL="https://github.com/opencontainers/runc/releases/download/v${RUNC_VERSION}/runc.${ARCH}"
+
+echo "Downloading runc ${RUNC_VERSION} from: $RUNC_URL"
+
+# Download runc binary and checksum
+curl -fsSL -o runc.${ARCH} ${RUNC_URL}
+
+sudo install -m 755 runc.${ARCH} /usr/local/sbin/runc
+
+echo "Runc ${RUNC_VERSION} installed successfully."
+
+# Install CNI plugins
+CNI_VERSION="1.1.1"
+CNI_TAR="cni-plugins-linux-${ARCH}-v${CNI_VERSION}.tgz"
+CNI_URL="https://github.com/containernetworking/plugins/releases/download/v${CNI_VERSION}/${CNI_TAR}"
+
+echo "Downloading CNI plugins from: $CNI_URL"
+
+# Download CNI tarball and checksum
+curl -fsSL -o ${CNI_TAR} ${CNI_URL}
+
+sudo mkdir -p /opt/cni/bin
+sudo tar Cxzvf /opt/cni/bin ${CNI_TAR}
+
+# Configure containerd
+sudo mkdir -p /etc/containerd
+
+# Generate base configuration
+sudo containerd config default | sudo tee /etc/containerd/config.toml > /dev/null
+
+# Configure based on version
+if [ "$MAJOR_VERSION" = "2" ]; then
+    # Containerd 2.x configuration
+    cat <<EOF | sudo tee /etc/containerd/config.toml > /dev/null
+version = 2
+root = "/var/lib/containerd"
+state = "/run/containerd"
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.9"
+    systemd_cgroup = true
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runc.v2"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            SystemdCgroup = true
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
+EOF
+else
+    # Containerd 1.x configuration
+    cat <<EOF | sudo tee /etc/containerd/config.toml > /dev/null
+version = 1
+root = "/var/lib/containerd"
+state = "/run/containerd"
+
+[grpc]
+  address = "/run/containerd/containerd.sock"
+  uid = 0
+  gid = 0
+
+[plugins]
+  [plugins."io.containerd.grpc.v1.cri"]
+    sandbox_image = "registry.k8s.io/pause:3.9"
+    systemd_cgroup = true
+    [plugins."io.containerd.grpc.v1.cri".containerd]
+      [plugins."io.containerd.grpc.v1.cri".containerd.runtimes]
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc]
+          runtime_type = "io.containerd.runtime.v1.linux"
+          [plugins."io.containerd.grpc.v1.cri".containerd.runtimes.runc.options]
+            SystemdCgroup = true
+    [plugins."io.containerd.grpc.v1.cri".registry]
+      [plugins."io.containerd.grpc.v1.cri".registry.mirrors]
+        [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+          endpoint = ["https://registry-1.docker.io"]
+EOF
+fi
+
+# Set up systemd service for containerd
+sudo curl -fsSL "https://raw.githubusercontent.com/containerd/containerd/main/containerd.service" -o /etc/systemd/system/containerd.service
+
+# Create containerd service directory
+sudo mkdir -p /etc/systemd/system/containerd.service.d
+
+# Add custom service configuration
+cat <<EOF | sudo tee /etc/systemd/system/containerd.service.d/override.conf > /dev/null
+[Service]
+ExecStart=
+ExecStart=/usr/local/bin/containerd
+Restart=always
+RestartSec=5
+Delegate=yes
+KillMode=process
+OOMScoreAdjust=-999
+LimitNOFILE=1048576
+LimitNPROC=infinity
+LimitCORE=infinity
+TasksMax=infinity
+# Ensure socket directory exists with correct permissions
+ExecStartPre=/bin/mkdir -p /run/containerd
+ExecStartPre=/bin/chmod 711 /run/containerd
+EOF
+
+# Reload systemd and start containerd
+sudo systemctl daemon-reload
+sudo systemctl enable --now containerd
+
+# Wait for containerd to be ready
+echo "Waiting for containerd to be ready..."
+timeout=60
+while ! sudo ctr version &>/dev/null; do
+    if [ $timeout -le 0 ]; then
+        echo "Timeout waiting for containerd to be ready"
+        exit 1
+    fi
+    sleep 1
+    timeout=$((timeout-1))
+done
+
+# Ensure socket permissions are correct
+sudo chmod 666 /run/containerd/containerd.sock
+
+# Verify installation
+echo "Verifying installation..."
+containerd --version
+runc --version
+sudo ctr version
+
+# Test containerd functionality
+echo "Testing containerd functionality..."
+sudo ctr images pull docker.io/library/hello-world:latest
+sudo ctr run --rm docker.io/library/hello-world:latest test
+
+echo "Containerd installation completed successfully!"
 `
 
 type Containerd struct {

--- a/pkg/provisioner/templates/containerd_test.go
+++ b/pkg/provisioner/templates/containerd_test.go
@@ -30,7 +30,35 @@ func TestNewContainerd_CustomVersion(t *testing.T) {
 	}
 }
 
-func TestContainerd_Execute(t *testing.T) {
+func TestNewContainerd_EmptyVersion(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Version: "",
+			},
+		},
+	}
+	c := NewContainerd(env)
+	if c.Version != "1.6.27" {
+		t.Errorf("expected default Version to be '1.6.27' when empty, got '%s'", c.Version)
+	}
+}
+
+func TestNewContainerd_Version2(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Version: "2.0.0",
+			},
+		},
+	}
+	c := NewContainerd(env)
+	if c.Version != "2.0.0" {
+		t.Errorf("expected Version to be '2.0.0', got '%s'", c.Version)
+	}
+}
+
+func TestContainerd_Execute_Version1(t *testing.T) {
 	env := v1alpha1.Environment{
 		Spec: v1alpha1.EnvironmentSpec{
 			ContainerRuntime: v1alpha1.ContainerRuntime{
@@ -45,7 +73,151 @@ func TestContainerd_Execute(t *testing.T) {
 		t.Fatalf("Execute failed: %v", err)
 	}
 	out := buf.String()
-	if !strings.Contains(out, "sed -i 's/SystemdCgroup \\= false/SystemdCgroup \\= true/g' /etc/containerd/config.toml") {
-		t.Errorf("template output missing cgroup sed command: %s", out)
+
+	// Test version detection
+	if !strings.Contains(out, "MAJOR_VERSION=$(echo $CONTAINERD_VERSION | cut -d. -f1)") {
+		t.Error("template output missing version detection")
+	}
+
+	// Test 1.x specific configuration
+	if !strings.Contains(out, "version = 1") {
+		t.Error("template output missing version 1 configuration")
+	}
+	if !strings.Contains(out, "runtime_type = \"io.containerd.runtime.v1.linux\"") {
+		t.Error("template output missing 1.x runtime configuration")
+	}
+
+	// Test common configuration
+	if !strings.Contains(out, "systemd_cgroup = true") {
+		t.Error("template output missing systemd cgroup configuration")
+	}
+	if !strings.Contains(out, "sandbox_image = \"registry.k8s.io/pause:3.9\"") {
+		t.Error("template output missing sandbox image configuration")
+	}
+}
+
+func TestContainerd_Execute_Version2(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Version: "2.0.0",
+			},
+		},
+	}
+	c := NewContainerd(env)
+	var buf bytes.Buffer
+	err := c.Execute(&buf, env)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	out := buf.String()
+
+	// Test version detection
+	if !strings.Contains(out, "MAJOR_VERSION=$(echo $CONTAINERD_VERSION | cut -d. -f1)") {
+		t.Error("template output missing version detection")
+	}
+
+	// Test 2.x specific configuration
+	if !strings.Contains(out, "version = 2") {
+		t.Error("template output missing version 2 configuration")
+	}
+	if !strings.Contains(out, "runtime_type = \"io.containerd.runc.v2\"") {
+		t.Error("template output missing 2.x runtime configuration")
+	}
+
+	// Test common configuration
+	if !strings.Contains(out, "systemd_cgroup = true") {
+		t.Error("template output missing systemd cgroup configuration")
+	}
+	if !strings.Contains(out, "sandbox_image = \"registry.k8s.io/pause:3.9\"") {
+		t.Error("template output missing sandbox image configuration")
+	}
+}
+
+func TestContainerd_Execute_SystemChecks(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Version: "1.6.27",
+			},
+		},
+	}
+	c := NewContainerd(env)
+	var buf bytes.Buffer
+	err := c.Execute(&buf, env)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	out := buf.String()
+
+	// Test systemd check
+	if !strings.Contains(out, "if ! command -v systemctl &> /dev/null") {
+		t.Error("template output missing systemd check")
+	}
+
+	// Test kernel module handling
+	if !strings.Contains(out, "REQUIRED_MODULES=\"overlay br_netfilter\"") {
+		t.Error("template output missing required modules check")
+	}
+	if !strings.Contains(out, "sudo modprobe ${module}") {
+		t.Error("template output missing sudo module loading")
+	}
+	if !strings.Contains(out, "/etc/modules-load.d/${module}.conf") {
+		t.Error("template output missing module persistence")
+	}
+
+	// Test sysctl settings
+	if !strings.Contains(out, "sudo sysctl -n $key") {
+		t.Error("template output missing sudo sysctl check")
+	}
+	if !strings.Contains(out, "sudo sysctl -w $key=$value") {
+		t.Error("template output missing sudo sysctl setting")
+	}
+	if !strings.Contains(out, "sudo sysctl --system") {
+		t.Error("template output missing sudo sysctl apply")
+	}
+
+	// Test architecture check
+	if !strings.Contains(out, "if [[ \"$ARCH\" == \"x86_64\" ]]") {
+		t.Error("template output missing x86_64 architecture check")
+	}
+	if !strings.Contains(out, "ARCH=\"amd64\"") {
+		t.Error("template output missing x86_64 to amd64 mapping")
+	}
+	if !strings.Contains(out, "elif [[ \"$ARCH\" == \"aarch64\" ]]") {
+		t.Error("template output missing aarch64 architecture check")
+	}
+	if !strings.Contains(out, "ARCH=\"arm64\"") {
+		t.Error("template output missing aarch64 to arm64 mapping")
+	}
+	if !strings.Contains(out, "else") {
+		t.Error("template output missing else clause for unsupported architectures")
+	}
+
+	// Test temporary directory handling
+	if !strings.Contains(out, "TMP_DIR=$(mktemp -d)") {
+		t.Error("template output missing temporary directory creation")
+	}
+	if !strings.Contains(out, "rm -rf $TMP_DIR") {
+		t.Error("template output missing temporary directory cleanup")
+	}
+
+	// Test error handling
+	if !strings.Contains(out, "Error: Failed to download containerd tarball") {
+		t.Error("template output missing download error handling")
+	}
+	if !strings.Contains(out, "Error: Checksum verification failed for containerd") {
+		t.Error("template output missing checksum error handling")
+	}
+
+	// Test sudo usage in critical operations
+	if !strings.Contains(out, "sudo mkdir -p /etc/containerd") {
+		t.Error("template output missing sudo for directory creation")
+	}
+	if !strings.Contains(out, "sudo systemctl daemon-reload") {
+		t.Error("template output missing sudo for systemd reload")
+	}
+	if !strings.Contains(out, "sudo systemctl enable --now containerd") {
+		t.Error("template output missing sudo for service enable")
 	}
 }


### PR DESCRIPTION
This patch enabled installing containerd via binary download and manual setup, deprecating the APT (deb) package way.
This way we are more flexible and can install containerd versions not available on DEB repos

### Installation Process Improvements:
* [`pkg/provisioner/templates/containerd.go`](diffhunk://#diff-f5eedf7ae7a233835534a9abacc04d890767e7b712fcde69e9ef30fbd78ecd31L35-R149): Overhauled the containerd installation script to fetch the latest stable versions of containerd, runc, and CNI plugins, with added checksum verification for security.
* [`pkg/provisioner/templates/container-toolkit.go`](diffhunk://#diff-f335b722a830ac8e7308d5f71b3c20dfb3486e1a696420f0f4f44eeee400d5afL37-R37): Updated the installation command for the NVIDIA container toolkit to use the `install_packages_with_retry` function.