### PR TITLE
Add option to enable CDI via NVIDIA-CTK

### DIFF
--- a/api/holodeck/v1alpha1/types.go
+++ b/api/holodeck/v1alpha1/types.go
@@ -218,4 +218,8 @@ type NVIDIAContainerToolkit struct {
 	// If not set the latest stable version will be used
 	// +optional
 	Version string `json:"version"`
+	// EnableCDI enables the Container Device Interface (CDI) in the selected
+	// container runtime.
+	// +optional
+	EnableCDI bool `json:"enableCDI"`
 }

--- a/pkg/provisioner/templates/container-toolkit.go
+++ b/pkg/provisioner/templates/container-toolkit.go
@@ -37,12 +37,13 @@ curl -fsSL https://nvidia.github.io/libnvidia-container/gpgkey | sudo gpg --dear
 sudo apt-get install -y nvidia-container-toolkit
 
 # Configure container runtime
-sudo nvidia-ctk runtime configure --runtime={{.ContainerRuntime}} --set-as-default
+sudo nvidia-ctk runtime configure --runtime={{.ContainerRuntime}} --set-as-default --enable-cdi={{.EnableCDI}}
 sudo systemctl restart {{.ContainerRuntime}}
 `
 
 type ContainerToolkit struct {
 	ContainerRuntime string
+	EnableCDI        bool
 }
 
 func NewContainerToolkit(env v1alpha1.Environment) *ContainerToolkit {
@@ -50,9 +51,13 @@ func NewContainerToolkit(env v1alpha1.Environment) *ContainerToolkit {
 	if runtime == "" {
 		runtime = "containerd"
 	}
-	return &ContainerToolkit{
+
+	ctk := &ContainerToolkit{
 		ContainerRuntime: runtime,
+		EnableCDI:        env.Spec.NVIDIAContainerToolkit.EnableCDI,
 	}
+
+	return ctk
 }
 
 func (t *ContainerToolkit) Execute(tpl *bytes.Buffer, env v1alpha1.Environment) error {


### PR DESCRIPTION
This pull request introduces changes to enable the Container Device Interface (CDI) plugin in the NVIDIA Container Toolkit. The key changes involve adding a new configuration option for CDI in the `NVIDIAContainerToolkit` struct and updating the container runtime configuration script to support this option.

Configuration enhancements:

* [`api/holodeck/v1alpha1/types.go`](diffhunk://#diff-80dbbe64cf54baeca74c36848e2adf762002ba68edc6f0c546e167cd7781c2daR221-R223): Added a new boolean field `EnableCDI` to the `NVIDIAContainerToolkit` struct to enable the CDI plugin.

Runtime configuration updates:

* [`pkg/provisioner/templates/container-toolkit.go`](diffhunk://#diff-f335b722a830ac8e7308d5f71b3c20dfb3486e1a696420f0f4f44eeee400d5afL40-R65): Modified the container runtime configuration script to include the `--enable-cdi` flag based on the new `EnableCDI` field.
* [`pkg/provisioner/templates/container-toolkit.go`](diffhunk://#diff-f335b722a830ac8e7308d5f71b3c20dfb3486e1a696420f0f4f44eeee400d5afL40-R65): Updated the `ContainerToolkit` struct and its initialization logic to include the `EnableCDI` field, with a default value of `false`.