### PR TITLE
Run periodic cleanup over multiple AWS regions

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -7,6 +7,9 @@ on:
 jobs:
   cleanup:
     runs-on: linux-amd64-cpu4
+    strategy:
+      matrix:
+        aws-region: [us-west-1, us-east-1]
 
     steps:
       - name: Checkout repository
@@ -17,12 +20,12 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-          aws-region: us-west-1
+          aws-region: ${{ matrix.aws-region }}
 
       - name: Identify resources for deletion
         id: identify-resources
         run: |
-          # Find vpcs with Project holodeck and cicd Environment
+          # Find VPCs with tags Project=holodeck and Environment=cicd
           vpcs=$(aws ec2 describe-vpcs \
             --filters "Name=tag:Project,Values=holodeck" "Name=tag:Environment,Values=cicd" \
             --query "Vpcs[].VpcId" \


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/periodic.yaml` file to improve the AWS region handling and enhance the cleanup job. The key changes involve introducing a matrix strategy for AWS regions and updating the resource identification steps.

Enhancements to AWS region handling:

* [`.github/workflows/periodic.yaml`](diffhunk://#diff-c2a5b399abc1fb60d3b13971e01688a0f6ee14753bb695d4c25da7702723effbR10-R12): Added a matrix strategy to the `cleanup` job to run across multiple AWS regions (`us-west-1` and `us-east-1`).
* [`.github/workflows/periodic.yaml`](diffhunk://#diff-c2a5b399abc1fb60d3b13971e01688a0f6ee14753bb695d4c25da7702723effbL20-R28): Updated the `aws-region` parameter to use the matrix variable `${{ matrix.aws-region }}` instead of a hardcoded value.

Enhancements to resource identification:

* [`.github/workflows/periodic.yaml`](diffhunk://#diff-c2a5b399abc1fb60d3b13971e01688a0f6ee14753bb695d4c25da7702723effbL20-R28): Improved the comment in the resource identification step to clarify the tags used for filtering VPCs.

This change is needed given that the `k8s-nim-operator` is running on a different region than all other team projects due to EC2 instance type requirements.