### PR TITLE
Add unit tests across the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@ kubeconfig
 bin
 .DS_Store
 e2e_logs
-coverage.out
+coverage.out*

--- a/pkg/jyaml/jyaml_test.go
+++ b/pkg/jyaml/jyaml_test.go
@@ -1,0 +1,195 @@
+package jyaml
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"sigs.k8s.io/yaml"
+)
+
+type TestStruct struct {
+	Name    string `json:"name" yaml:"name"`
+	Age     int    `json:"age" yaml:"age"`
+	Address struct {
+		Street string `json:"street" yaml:"street"`
+		City   string `json:"city" yaml:"city"`
+	} `json:"address" yaml:"address"`
+}
+
+func TestMarshalJSON(t *testing.T) {
+	testData := TestStruct{
+		Name: "John",
+		Age:  30,
+		Address: struct {
+			Street string `json:"street" yaml:"street"`
+			City   string `json:"city" yaml:"city"`
+		}{
+			Street: "123 Main St",
+			City:   "New York",
+		},
+	}
+
+	data, err := MarshalJSON(testData)
+	if err != nil {
+		t.Errorf("MarshalJSON failed: %v", err)
+	}
+
+	// Verify the marshaled data can be unmarshaled back
+	var result TestStruct
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Errorf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if result.Name != testData.Name {
+		t.Errorf("Expected Name %q, got %q", testData.Name, result.Name)
+	}
+	if result.Age != testData.Age {
+		t.Errorf("Expected Age %d, got %d", testData.Age, result.Age)
+	}
+}
+
+func TestMarshalJSONIndent(t *testing.T) {
+	testData := TestStruct{
+		Name: "John",
+		Age:  30,
+	}
+
+	data, err := MarshalJSONIndent(testData, "", "  ")
+	if err != nil {
+		t.Errorf("MarshalJSONIndent failed: %v", err)
+	}
+
+	// Verify the marshaled data can be unmarshaled back
+	var result TestStruct
+	if err := json.Unmarshal(data, &result); err != nil {
+		t.Errorf("Failed to unmarshal JSON: %v", err)
+	}
+
+	if result.Name != testData.Name {
+		t.Errorf("Expected Name %q, got %q", testData.Name, result.Name)
+	}
+}
+
+func TestMarshalYAML(t *testing.T) {
+	testData := TestStruct{
+		Name: "John",
+		Age:  30,
+	}
+
+	data, err := MarshalYAML(testData)
+	if err != nil {
+		t.Errorf("MarshalYAML failed: %v", err)
+	}
+
+	// Verify the marshaled data can be unmarshaled back
+	var result TestStruct
+	if err := yaml.Unmarshal(data, &result); err != nil {
+		t.Errorf("Failed to unmarshal YAML: %v", err)
+	}
+
+	if result.Name != testData.Name {
+		t.Errorf("Expected Name %q, got %q", testData.Name, result.Name)
+	}
+}
+
+func TestUnmarshal(t *testing.T) {
+	yamlStr := `
+name: John
+age: 30
+address:
+  street: 123 Main St
+  city: New York
+`
+
+	result, err := Unmarshal[TestStruct](yamlStr)
+	if err != nil {
+		t.Errorf("Unmarshal failed: %v", err)
+	}
+
+	if result.Name != "John" {
+		t.Errorf("Expected Name %q, got %q", "John", result.Name)
+	}
+	if result.Age != 30 {
+		t.Errorf("Expected Age %d, got %d", 30, result.Age)
+	}
+}
+
+func TestUnmarshalStrict(t *testing.T) {
+	yamlStr := `
+name: John
+age: 30
+address:
+  street: 123 Main St
+  city: New York
+`
+
+	result, err := UnmarshalStrict[TestStruct](yamlStr)
+	if err != nil {
+		t.Errorf("UnmarshalStrict failed: %v", err)
+	}
+
+	if result.Name != "John" {
+		t.Errorf("Expected Name %q, got %q", "John", result.Name)
+	}
+}
+
+func TestUnmarshalFromFile(t *testing.T) {
+	// Create a temporary file with test data
+	tempFile, err := os.CreateTemp("", "test-*.yaml")
+	if err != nil {
+		t.Fatalf("Failed to create temp file: %v", err)
+	}
+	defer os.Remove(tempFile.Name()) //nolint:errcheck,gosec
+
+	yamlContent := `
+name: John
+age: 30
+address:
+  street: 123 Main St
+  city: New York
+`
+	if _, err := tempFile.Write([]byte(yamlContent)); err != nil {
+		t.Fatalf("Failed to write to temp file: %v", err)
+	}
+	if err := tempFile.Close(); err != nil {
+		t.Errorf("failed to close temp file: %v", err)
+	}
+
+	result, err := UnmarshalFromFile[TestStruct](tempFile.Name())
+	if err != nil {
+		t.Errorf("UnmarshalFromFile failed: %v", err)
+	}
+
+	if result.Name != "John" {
+		t.Errorf("Expected Name %q, got %q", "John", result.Name)
+	}
+	if result.Age != 30 {
+		t.Errorf("Expected Age %d, got %d", 30, result.Age)
+	}
+}
+
+func TestUnmarshalWithInvalidData(t *testing.T) {
+	invalidYAML := `
+name: John
+age: "not a number"  # This should be a number
+`
+
+	_, err := Unmarshal[TestStruct](invalidYAML)
+	if err == nil {
+		t.Error("Expected error for invalid YAML, got nil")
+	}
+}
+
+func TestUnmarshalStrictWithUnknownFields(t *testing.T) {
+	yamlWithUnknownFields := `
+name: John
+age: 30
+unknown_field: value
+`
+
+	_, err := UnmarshalStrict[TestStruct](yamlWithUnknownFields)
+	if err == nil {
+		t.Error("Expected error for unknown fields in strict mode, got nil")
+	}
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,157 @@
+package provider
+
+import (
+	"errors"
+	"testing"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// MockProvider is a mock implementation of the Provider interface
+type MockProvider struct {
+	name            string
+	createError     error
+	deleteError     error
+	dryRunError     error
+	statusError     error
+	updateTagsError error
+	conditions      []metav1.Condition
+}
+
+func (m *MockProvider) Name() string {
+	return m.name
+}
+
+func (m *MockProvider) Create() error {
+	return m.createError
+}
+
+func (m *MockProvider) Delete() error {
+	return m.deleteError
+}
+
+func (m *MockProvider) DryRun() error {
+	return m.dryRunError
+}
+
+func (m *MockProvider) Status() ([]metav1.Condition, error) {
+	return m.conditions, m.statusError
+}
+
+func (m *MockProvider) UpdateResourcesTags(tags map[string]string, resources ...string) error {
+	return m.updateTagsError
+}
+
+func TestProviderInterface(t *testing.T) {
+	tests := []struct {
+		name           string
+		provider       *MockProvider
+		expectedName   string
+		expectedError  error
+		expectedStatus []metav1.Condition
+	}{
+		{
+			name: "successful provider",
+			provider: &MockProvider{
+				name: "test-provider",
+				conditions: []metav1.Condition{
+					{
+						Type:   "Ready",
+						Status: "True",
+					},
+				},
+			},
+			expectedName:  "test-provider",
+			expectedError: nil,
+			expectedStatus: []metav1.Condition{
+				{
+					Type:   "Ready",
+					Status: "True",
+				},
+			},
+		},
+		{
+			name: "provider with create error",
+			provider: &MockProvider{
+				name:        "error-provider",
+				createError: errors.New("create error"),
+			},
+			expectedName:  "error-provider",
+			expectedError: errors.New("create error"),
+		},
+		{
+			name: "provider with delete error",
+			provider: &MockProvider{
+				name:        "error-provider",
+				deleteError: errors.New("delete error"),
+			},
+			expectedName:  "error-provider",
+			expectedError: errors.New("delete error"),
+		},
+		{
+			name: "provider with dry run error",
+			provider: &MockProvider{
+				name:        "error-provider",
+				dryRunError: errors.New("dry run error"),
+			},
+			expectedName:  "error-provider",
+			expectedError: errors.New("dry run error"),
+		},
+		{
+			name: "provider with status error",
+			provider: &MockProvider{
+				name:        "error-provider",
+				statusError: errors.New("status error"),
+			},
+			expectedName:  "error-provider",
+			expectedError: errors.New("status error"),
+		},
+		{
+			name: "provider with update tags error",
+			provider: &MockProvider{
+				name:            "error-provider",
+				updateTagsError: errors.New("update tags error"),
+			},
+			expectedName:  "error-provider",
+			expectedError: errors.New("update tags error"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Test Name()
+			if got := tt.provider.Name(); got != tt.expectedName {
+				t.Errorf("Name() = %v, want %v", got, tt.expectedName)
+			}
+
+			// Test Create()
+			if err := tt.provider.Create(); err != nil && err.Error() != tt.provider.createError.Error() {
+				t.Errorf("Create() error = %v, want %v", err, tt.provider.createError)
+			}
+
+			// Test Delete()
+			if err := tt.provider.Delete(); err != nil && err.Error() != tt.provider.deleteError.Error() {
+				t.Errorf("Delete() error = %v, want %v", err, tt.provider.deleteError)
+			}
+
+			// Test DryRun()
+			if err := tt.provider.DryRun(); err != nil && err.Error() != tt.provider.dryRunError.Error() {
+				t.Errorf("DryRun() error = %v, want %v", err, tt.provider.dryRunError)
+			}
+
+			// Test Status()
+			conditions, err := tt.provider.Status()
+			if err != nil && err.Error() != tt.provider.statusError.Error() {
+				t.Errorf("Status() error = %v, want %v", err, tt.provider.statusError)
+			}
+			if err == nil && len(conditions) != len(tt.expectedStatus) {
+				t.Errorf("Status() conditions length = %v, want %v", len(conditions), len(tt.expectedStatus))
+			}
+
+			// Test UpdateResourcesTags()
+			if err := tt.provider.UpdateResourcesTags(map[string]string{"key": "value"}); err != nil && err.Error() != tt.provider.updateTagsError.Error() {
+				t.Errorf("UpdateResourcesTags() error = %v, want %v", err, tt.provider.updateTagsError)
+			}
+		})
+	}
+}

--- a/pkg/provisioner/dependency_test.go
+++ b/pkg/provisioner/dependency_test.go
@@ -1,0 +1,104 @@
+package provisioner
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/holodeck/api/holodeck/v1alpha1"
+)
+
+func TestNewDependencies(t *testing.T) {
+	env := v1alpha1.Environment{}
+	d := NewDependencies(env)
+	if d == nil { //nolint:staticcheck
+		t.Fatal("NewDependencies returned nil")
+	}
+	if len(d.Dependencies) != 0 { //nolint:staticcheck
+		t.Errorf("expected empty dependencies, got %d", len(d.Dependencies))
+	}
+}
+
+func TestDependencyResolver_WithKubernetes(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			Kubernetes: v1alpha1.Kubernetes{
+				KubernetesInstaller: "kubeadm",
+			},
+		},
+	}
+	d := NewDependencies(env)
+	d.withKubernetes()
+	if len(d.Dependencies) != 1 {
+		t.Errorf("expected 1 dependency, got %d", len(d.Dependencies))
+	}
+}
+
+func TestDependencyResolver_WithContainerRuntime(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Name: "containerd",
+			},
+		},
+	}
+	d := NewDependencies(env)
+	d.withContainerRuntime()
+	if len(d.Dependencies) != 1 {
+		t.Errorf("expected 1 dependency, got %d", len(d.Dependencies))
+	}
+}
+
+func TestDependencyResolver_WithContainerToolkit(t *testing.T) {
+	env := v1alpha1.Environment{}
+	d := NewDependencies(env)
+	d.withContainerToolkit()
+	if len(d.Dependencies) != 1 {
+		t.Errorf("expected 1 dependency, got %d", len(d.Dependencies))
+	}
+}
+
+func TestDependencyResolver_WithNVDriver(t *testing.T) {
+	env := v1alpha1.Environment{}
+	d := NewDependencies(env)
+	d.withNVDriver()
+	if len(d.Dependencies) != 1 {
+		t.Errorf("expected 1 dependency, got %d", len(d.Dependencies))
+	}
+}
+
+func TestDependencyResolver_WithKernel(t *testing.T) {
+	env := v1alpha1.Environment{}
+	d := NewDependencies(env)
+	d.withKernel()
+	if len(d.Dependencies) != 1 {
+		t.Errorf("expected 1 dependency, got %d", len(d.Dependencies))
+	}
+}
+
+func TestDependencyResolver_Resolve(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			Kubernetes: v1alpha1.Kubernetes{
+				Install:             true,
+				KubernetesInstaller: "kubeadm",
+			},
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Install: true,
+				Name:    "containerd",
+			},
+			NVIDIAContainerToolkit: v1alpha1.NVIDIAContainerToolkit{
+				Install: true,
+			},
+			NVIDIADriver: v1alpha1.NVIDIADriver{
+				Install: true,
+			},
+			Kernel: v1alpha1.Kernel{
+				Version: "5.4.0",
+			},
+		},
+	}
+	d := NewDependencies(env)
+	deps := d.Resolve()
+	if len(deps) != 5 {
+		t.Errorf("expected 5 dependencies, got %d", len(deps))
+	}
+}

--- a/pkg/provisioner/dryrun_test.go
+++ b/pkg/provisioner/dryrun_test.go
@@ -1,0 +1,74 @@
+package provisioner
+
+import (
+	"testing"
+
+	"github.com/NVIDIA/holodeck/api/holodeck/v1alpha1"
+	"github.com/NVIDIA/holodeck/internal/logger"
+)
+
+func TestDryrun_ValidKubernetesVersion(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			Kubernetes: v1alpha1.Kubernetes{
+				Install:             true,
+				KubernetesInstaller: "kubeadm",
+				KubernetesVersion:   "v1.20.0",
+			},
+		},
+	}
+	log := logger.NewLogger()
+	err := Dryrun(log, env)
+	if err != nil {
+		t.Errorf("Dryrun failed: %v", err)
+	}
+}
+
+func TestDryrun_InvalidKubernetesVersion(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			Kubernetes: v1alpha1.Kubernetes{
+				Install:             true,
+				KubernetesInstaller: "kubeadm",
+				KubernetesVersion:   "1.20.0",
+			},
+		},
+	}
+	log := logger.NewLogger()
+	err := Dryrun(log, env)
+	if err == nil {
+		t.Error("Dryrun did not fail with invalid kubernetes version")
+	}
+}
+
+func TestDryrun_ValidContainerRuntime(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Install: true,
+				Name:    "containerd",
+			},
+		},
+	}
+	log := logger.NewLogger()
+	err := Dryrun(log, env)
+	if err != nil {
+		t.Errorf("Dryrun failed: %v", err)
+	}
+}
+
+func TestDryrun_InvalidContainerRuntime(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Install: true,
+				Name:    "invalid",
+			},
+		},
+	}
+	log := logger.NewLogger()
+	err := Dryrun(log, env)
+	if err == nil {
+		t.Error("Dryrun did not fail with invalid container runtime")
+	}
+}

--- a/pkg/provisioner/templates/container-toolkit_test.go
+++ b/pkg/provisioner/templates/container-toolkit_test.go
@@ -1,0 +1,63 @@
+package templates
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/holodeck/api/holodeck/v1alpha1"
+)
+
+func TestNewContainerToolkit_Defaults(t *testing.T) {
+	env := v1alpha1.Environment{}
+	ctk := NewContainerToolkit(env)
+	if ctk.ContainerRuntime != "containerd" {
+		t.Errorf("expected default ContainerRuntime to be 'containerd', got '%s'", ctk.ContainerRuntime)
+	}
+	if ctk.EnableCDI != false {
+		t.Errorf("expected default EnableCDI to be false, got %v", ctk.EnableCDI)
+	}
+}
+
+func TestNewContainerToolkit_Custom(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Name: "docker",
+			},
+			NVIDIAContainerToolkit: v1alpha1.NVIDIAContainerToolkit{
+				EnableCDI: true,
+			},
+		},
+	}
+	ctk := NewContainerToolkit(env)
+	if ctk.ContainerRuntime != "docker" {
+		t.Errorf("expected ContainerRuntime to be 'docker', got '%s'", ctk.ContainerRuntime)
+	}
+	if ctk.EnableCDI != true {
+		t.Errorf("expected EnableCDI to be true, got %v", ctk.EnableCDI)
+	}
+}
+
+func TestContainerToolkit_Execute(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Name: "containerd",
+			},
+			NVIDIAContainerToolkit: v1alpha1.NVIDIAContainerToolkit{
+				EnableCDI: true,
+			},
+		},
+	}
+	ctk := NewContainerToolkit(env)
+	var buf bytes.Buffer
+	err := ctk.Execute(&buf, env)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "nvidia-ctk runtime configure --runtime=containerd --set-as-default --enable-cdi=true") {
+		t.Errorf("template output missing expected runtime config: %s", out)
+	}
+}

--- a/pkg/provisioner/templates/containerd_test.go
+++ b/pkg/provisioner/templates/containerd_test.go
@@ -1,0 +1,51 @@
+package templates
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/holodeck/api/holodeck/v1alpha1"
+)
+
+func TestNewContainerd_Defaults(t *testing.T) {
+	env := v1alpha1.Environment{}
+	c := NewContainerd(env)
+	if c.Version != "1.6.27" {
+		t.Errorf("expected default Version to be '1.6.27', got '%s'", c.Version)
+	}
+}
+
+func TestNewContainerd_CustomVersion(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Version: "v1.7.0",
+			},
+		},
+	}
+	c := NewContainerd(env)
+	if c.Version != "1.7.0" {
+		t.Errorf("expected Version to be '1.7.0', got '%s'", c.Version)
+	}
+}
+
+func TestContainerd_Execute(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Version: "1.6.27",
+			},
+		},
+	}
+	c := NewContainerd(env)
+	var buf bytes.Buffer
+	err := c.Execute(&buf, env)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "sed -i 's/SystemdCgroup \\= false/SystemdCgroup \\= true/g' /etc/containerd/config.toml") {
+		t.Errorf("template output missing cgroup sed command: %s", out)
+	}
+}

--- a/pkg/provisioner/templates/crio_test.go
+++ b/pkg/provisioner/templates/crio_test.go
@@ -1,0 +1,46 @@
+package templates
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/holodeck/api/holodeck/v1alpha1"
+)
+
+func TestNewCriO(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Version: "1.25",
+			},
+		},
+	}
+	crio := NewCriO(env)
+	if crio.Version != "1.25" {
+		t.Errorf("expected Version to be '1.25', got '%s'", crio.Version)
+	}
+}
+
+func TestCriO_Execute(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Version: "1.25",
+			},
+		},
+	}
+	crio := NewCriO(env)
+	var buf bytes.Buffer
+	err := crio.Execute(&buf, env)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "apt install -y cri-o") {
+		t.Errorf("template output missing cri-o install: %s", out)
+	}
+	if !strings.Contains(out, "systemctl start crio.service") {
+		t.Errorf("template output missing crio start: %s", out)
+	}
+}

--- a/pkg/provisioner/templates/docker_test.go
+++ b/pkg/provisioner/templates/docker_test.go
@@ -1,0 +1,57 @@
+package templates
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/NVIDIA/holodeck/api/holodeck/v1alpha1"
+)
+
+func TestNewDocker_Defaults(t *testing.T) {
+	env := v1alpha1.Environment{}
+	d := NewDocker(env)
+	if d.Version != "latest" {
+		t.Errorf("expected default Version to be 'latest', got '%s'", d.Version)
+	}
+}
+
+func TestNewDocker_CustomVersion(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Version: "20.10.7",
+			},
+		},
+	}
+	d := NewDocker(env)
+	if d.Version != "20.10.7" {
+		t.Errorf("expected Version to be '20.10.7', got '%s'", d.Version)
+	}
+}
+
+func TestDocker_Execute(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			ContainerRuntime: v1alpha1.ContainerRuntime{
+				Version: "20.10.7",
+			},
+		},
+	}
+	d := NewDocker(env)
+	var buf bytes.Buffer
+	err := d.Execute(&buf, env)
+	if err != nil {
+		t.Fatalf("Execute failed: %v", err)
+	}
+	out := buf.String()
+	if !strings.Contains(out, "docker-ce=$DOCKER_VERSION") {
+		t.Errorf("template output missing expected docker version install command: %s", out)
+	}
+	if !strings.Contains(out, ": ${DOCKER_VERSION:=20.10.7}") {
+		t.Errorf("template output missing version assignment: %s", out)
+	}
+	if !strings.Contains(out, "systemctl enable docker") {
+		t.Errorf("template output missing enable docker: %s", out)
+	}
+}


### PR DESCRIPTION
This pull request introduces comprehensive unit tests across multiple packages to ensure functionality and reliability of YAML/JSON marshaling, provider interfaces, dependency resolution, dry-run validations, and container runtime templates. The changes focus on improving test coverage and validating different configurations and edge cases.

### Testing for YAML/JSON marshaling and unmarshaling:
* Added tests in `pkg/jyaml/jyaml_test.go` to validate `MarshalJSON`, `MarshalJSONIndent`, `MarshalYAML`, `Unmarshal`, `UnmarshalStrict`, and `UnmarshalFromFile` functions, including scenarios with invalid data and strict mode validation.

### Mocking and testing provider interfaces:
* Introduced `MockProvider` in `pkg/provider/provider_test.go` to test the `Provider` interface, including methods like `Create`, `Delete`, `DryRun`, `Status`, and `UpdateResourcesTags`. Added test cases for both successful and error scenarios.

### Dependency resolution testing:
* Implemented tests in `pkg/provisioner/dependency_test.go` for `NewDependencies` and its methods (`withKubernetes`, `withContainerRuntime`, etc.), as well as the `Resolve` method to validate dependency resolution logic.

### Dry-run validation:
* Added dry-run tests in `pkg/provisioner/dryrun_test.go` to validate configurations for Kubernetes versions and container runtimes, including both valid and invalid scenarios.

### Container runtime template testing:
* [`pkg/provisioner/templates/container-toolkit_test.go`](diffhunk://#diff-52beecb07cfa50dc6e1d29a9b13b554f9f8baba08de3d9f17e89767220239736R1-R63): Added tests for `NewContainerToolkit` and its `Execute` method to validate default and custom configurations.
* [`pkg/provisioner/templates/containerd_test.go`](diffhunk://#diff-86f17253125f2976f34e61b0b8300add3fd7ffb713a733cddcd193dff4bfc2e9R1-R51): Added tests for `NewContainerd` and its `Execute` method, ensuring correct version handling and configuration commands.
* [`pkg/provisioner/templates/crio_test.go`](diffhunk://#diff-b2542f0c7229b3ce3e06240a3c5f923c7b855b42976728e33a7ba21f2b939c06R1-R46): Added tests for `NewCriO` and its `Execute` method to validate CRI-O installation and service start commands.
* [`pkg/provisioner/templates/docker_test.go`](diffhunk://#diff-247e00c9ab5079a2d04989f99d1b3241e22cf313c1118f94bf7adc19a7faa1b2R1-R57): Added tests for `NewDocker` and its `Execute` method to validate Docker versioning and service enablement.