### PR TITLE
Bug fixes after v0.2.8 release

### DIFF
--- a/cmd/cli/delete/delete.go
+++ b/cmd/cli/delete/delete.go
@@ -24,7 +24,6 @@ import (
 	"github.com/NVIDIA/holodeck/api/holodeck/v1alpha1"
 	"github.com/NVIDIA/holodeck/internal/instances"
 	"github.com/NVIDIA/holodeck/internal/logger"
-	"github.com/NVIDIA/holodeck/pkg/jyaml"
 
 	cli "github.com/urfave/cli/v2"
 )
@@ -32,7 +31,6 @@ import (
 type command struct {
 	log       *logger.FunLogger
 	cachePath string
-	envFile   string
 	cfg       v1alpha1.Environment
 }
 
@@ -58,49 +56,13 @@ func (m command) build() *cli.Command {
 				Value:       filepath.Join(os.Getenv("HOME"), ".cache", "holodeck"),
 			},
 			&cli.StringFlag{
-				Name:        "envFile",
-				Aliases:     []string{"f"},
-				Usage:       "Path to the Environment file",
-				Destination: &m.envFile,
-			},
-			&cli.StringFlag{
 				Name:    "instance-id",
 				Aliases: []string{"i"},
 				Usage:   "Instance ID to delete",
 			},
 		},
-		Before: func(c *cli.Context) error {
-			// Check that either envFile or instance-id is provided, but not both
-			hasEnvFile := c.IsSet("envFile")
-			hasInstanceID := c.IsSet("instance-id")
 
-			if hasEnvFile && hasInstanceID {
-				return fmt.Errorf("cannot specify both --envFile and --instance-id")
-			}
-			if !hasEnvFile && !hasInstanceID {
-				return fmt.Errorf("must specify either --envFile or --instance-id")
-			}
-
-			// Read the config file if provided
-			if hasEnvFile {
-				var err error
-				m.cfg, err = jyaml.UnmarshalFromFile[v1alpha1.Environment](m.envFile)
-				if err != nil {
-					return fmt.Errorf("error reading config file: %s", err)
-				}
-			}
-			return nil
-		},
 		Action: func(c *cli.Context) error {
-			if c.IsSet("envFile") {
-				// Delete using environment file
-				instanceID := m.cfg.Labels[instances.InstanceLabelKey]
-				if instanceID == "" {
-					return fmt.Errorf("environment file does not contain an instance ID")
-				}
-				return m.run(c, instanceID)
-			}
-
 			// Delete using instance ID
 			instanceID := c.String("instance-id")
 			return m.run(c, instanceID)

--- a/cmd/cli/list/list.go
+++ b/cmd/cli/list/list.go
@@ -82,7 +82,6 @@ func (m command) run(c *cli.Context) error {
 	for _, instance := range instances {
 		// Skip instances without an ID (old cache files)
 		if instance.ID == "" {
-			m.log.Warning("Found old cache file without instance ID, skipping: %s", instance.CacheFile)
 			continue
 		}
 

--- a/internal/instances/instances.go
+++ b/internal/instances/instances.go
@@ -111,7 +111,11 @@ func (m *Manager) getProviderStatus(env v1alpha1.Environment, cacheFile string) 
 				}
 			case v1alpha1.ConditionDegraded:
 				if condition.Status == metav1.ConditionTrue {
-					status = "degraded"
+					if condition.Reason != "" {
+						status = fmt.Sprintf("degraded (%s)", condition.Reason)
+					} else {
+						status = "degraded"
+					}
 					statusFound = true
 				}
 			case v1alpha1.ConditionProgressing:
@@ -173,7 +177,6 @@ func (m *Manager) ListInstances() ([]Instance, error) {
 				env.Labels[InstanceLabelKey] = instanceID
 			} else {
 				// Skip files that don't have an instance ID and aren't UUIDs
-				m.log.Warning("Found old cache file without instance ID, skipping: %s", cacheFile)
 				continue
 			}
 		}

--- a/pkg/provisioner/templates/kernel.go
+++ b/pkg/provisioner/templates/kernel.go
@@ -38,8 +38,6 @@ echo "Current kernel version: $CURRENT_KERNEL"
 KERNEL_VERSION="{{ .Spec.Kernel.Version }}"
 
 if [ "${CURRENT_KERNEL}" != "${KERNEL_VERSION}" ]; then
-    echo "--------------Upgrading kernel to ${KERNEL_VERSION}--------------"
-    
     # Update package lists
     sudo apt-get update -y || true
     
@@ -61,10 +59,6 @@ if [ "${CURRENT_KERNEL}" != "${KERNEL_VERSION}" ]; then
     echo "Rebooting..."
     # Run the reboot command with nohup to avoid abrupt SSH closure issues
     nohup sudo reboot &
-    
-    echo "--------------Kernel upgrade completed--------------"
-else
-    echo "--------------Kernel upgrade not required, current kernel version ${KERNEL_VERSION}--------------"
 fi
 {{- end }}
 `

--- a/pkg/provisioner/templates/kubernetes.go
+++ b/pkg/provisioner/templates/kubernetes.go
@@ -104,10 +104,8 @@ export KUBECONFIG="${HOME}/.kube/config"
 
 # Install Calico
 # based on https://docs.tigera.io/calico/latest/getting-started/kubernetes/quickstart
-with_retry 3 10s kubectl --kubeconfig $KUBECONFIG create -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/tigera-operator.yaml
-# Calico CRDs created. Now we sleep for 10s to ensure they are fully registered in the K8s etcd
-sleep 10s
-with_retry 3 10s kubectl --kubeconfig $KUBECONFIG apply -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/custom-resources.yaml
+with_retry 5 10s kubectl --kubeconfig $KUBECONFIG create -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/tigera-operator.yaml
+with_retry 5 10s kubectl --kubeconfig $KUBECONFIG create -f https://raw.githubusercontent.com/projectcalico/calico/${CALICO_VERSION}/manifests/custom-resources.yaml
 # Make single-node cluster schedulable
 kubectl taint nodes --all node-role.kubernetes.io/control-plane:NoSchedule-
 kubectl label node --all node-role.kubernetes.io/worker=
@@ -445,7 +443,7 @@ func GetCRISocket(runtime string) (string, error) {
 	}
 }
 
-// isLegacyKubernetesVersion checks if the Kubernetes version is older than v1.30.0
+// isLegacyKubernetesVersion checks if the Kubernetes version is older than v1.32.0
 // which requires using legacy kubeadm init flags instead of config file
 func isLegacyKubernetesVersion(version string) bool {
 	// Remove 'v' prefix if present
@@ -461,6 +459,6 @@ func isLegacyKubernetesVersion(version string) bool {
 	major, _ := strconv.Atoi(parts[0])
 	minor, _ := strconv.Atoi(parts[1])
 
-	// Return true if version is older than v1.30.0
-	return major < 1 || (major == 1 && minor < 30)
+	// Return true if version is older than v1.32.0
+	return major < 1 || (major == 1 && minor < 32)
 }

--- a/pkg/provisioner/templates/nv-driver.go
+++ b/pkg/provisioner/templates/nv-driver.go
@@ -34,8 +34,17 @@ wget https://developer.download.nvidia.com/compute/cuda/repos/$distribution/x86_
 sudo dpkg -i cuda-keyring_1.1-1_all.deb
 
 with_retry 3 10s sudo apt-get update
-install_packages_with_retry cuda-drivers{{if .Version}}={{.Version}}{{else if .Branch}}-{{.Branch}}{{end}}
+install_packages_with_retry nvidia-driver{{if .Version}}={{.Version}}{{else if .Branch}}-{{.Branch}}{{end}}
 
+# Check if NVIDIA module is loaded, if not load it
+if ! lsmod | grep -q "^nvidia "; then
+    sudo modprobe nvidia
+fi
+
+# Start nvidia-persistenced
+sudo nvidia-persistenced --persistence-mode
+
+# Quick check to see if the driver is installed
 nvidia-smi
 `
 


### PR DESCRIPTION
This pull request introduces several changes across multiple areas of the codebase, these changes are fixes to changes introduced during the last release cut.

### Error Handling and Status Updates:
* Added logic to set a "Degraded" condition with detailed error information when provisioning fails, and updated the cache file with the provisioning status in `runProvision` (`cmd/cli/create/create.go`).
* Enhanced the `getProviderStatus` function to include the reason for a degraded status in the status message (`internal/instances/instances.go`).

### CLI Simplification:
* Removed the `envFile` flag and its associated logic from the `delete` command, simplifying the deletion process to rely solely on the `instance-id` flag (`cmd/cli/delete/delete.go`).

### Provisioning Templates:
* Updated the NVIDIA driver installation script to include additional checks (e.g., loading the NVIDIA module and starting `nvidia-persistenced`) and improved driver validation (`pkg/provisioner/templates/nv-driver.go`).
* Adjusted Kubernetes provisioning logic to retry Calico resource creation up to 5 times and updated the legacy Kubernetes version check to v1.32.0 (`pkg/provisioner/templates/kubernetes.go`). [[1]](diffhunk://#diff-c4959d6dcff90ac438f4f51664cdb720c757988807bd42f5075f9fd47329742dL107-R108) [[2]](diffhunk://#diff-c4959d6dcff90ac438f4f51664cdb720c757988807bd42f5075f9fd47329742dL464-R463)

### Testing Enhancements:
* Introduced additional end-to-end tests for AWS environments, including validation of environment provisioning and Kubernetes cluster setup (`tests/aws_test.go`).

These changes collectively improve the robustness, usability, and maintainability of the codebase while enhancing the test coverage and reliability of the provisioning process.