### PR TITLE
Only generate ginkgo logs on gpu test

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -59,7 +59,11 @@ jobs:
         echo "${{ secrets.AWS_SSH_KEY }}" > "$e2e_ssh_key"
         chmod 600 "$e2e_ssh_key"
         export E2E_SSH_KEY="$e2e_ssh_key"
-        make -f tests/Makefile test GINKGO_ARGS="--label-filter='${{ matrix.label }}'"
+        if [ "${{ matrix.label }}" = "default" ]; then \
+          make -f tests/Makefile test GINKGO_ARGS="--label-filter='${{ matrix.label }}' --json-report ginkgo.json"; \
+        else \
+          make -f tests/Makefile test GINKGO_ARGS="--label-filter='${{ matrix.label }}'"; \
+        fi
 
     - name: Archive Ginkgo logs
       uses: actions/upload-artifact@v4

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -27,7 +27,7 @@ test: $(GINKGO_BIN)
 	CI=$(CI) \
 	ENV_FILE=$(ENV_FILE) \
 	GINKGO_FOCUS=$(GINKGO_FOCUS) \
-	$(GINKGO_BIN) $(GINKGO_ARGS) -v --json-report ginkgo.json ./tests/...
+	$(GINKGO_BIN) $(GINKGO_ARGS) -v ./tests/...
 
 $(GINKGO_BIN):
 	mkdir -p $(CURDIR)/bin


### PR DESCRIPTION
This pull request includes changes to the end-to-end (E2E) testing workflow and the `Makefile` for test execution. The updates introduce conditional logic for generating JSON reports only for specific test labels and simplify the test command in the `Makefile`.

### Updates to E2E Testing Workflow:

* [`.github/workflows/e2e.yaml`](diffhunk://#diff-a2de7550554c0198ac7f959c78a19ee0996921c98034411de47a7dd49b0c209bL62-R66): Added conditional logic to generate a `ginkgo.json` report when the test label is "default." This ensures JSON reports are only created for the default test suite, optimizing artifact generation.

### Changes to Test Execution in `Makefile`:

* [`tests/Makefile`](diffhunk://#diff-36b847ebf9c22d0651fe4856d7a8acb47ee2c483c79f1ccf0ed8c84889c9a394L30-R30): Removed the `--json-report ginkgo.json` flag from the default test command, as this is now handled conditionally in the workflow configuration. This simplifies the `Makefile` logic.