### PR TITLE
Remove duplicate template execution code in container-toolkit.go

### DIFF
--- a/pkg/provisioner/templates/container-toolkit.go
+++ b/pkg/provisioner/templates/container-toolkit.go
@@ -67,9 +67,5 @@ func (t *ContainerToolkit) Execute(tpl *bytes.Buffer, env v1alpha1.Environment) 
 		return fmt.Errorf("failed to execute container-toolkit template: %v", err)
 	}
 
-	if err := containerTlktTemplate.Execute(tpl, t); err != nil {
-		return fmt.Errorf("failed to execute container-toolkit template: %v", err)
-	}
-
 	return nil
 }


### PR DESCRIPTION
The Execute method had redundant template execution logic that was already handled earlier in the function. This change removes the duplicate code block to clean up the implementation.