### PR TITLE
Create IP detection utils and use in AWS security group creation 

### DIFF
--- a/api/holodeck/v1alpha1/types.go
+++ b/api/holodeck/v1alpha1/types.go
@@ -65,7 +65,7 @@ type Instance struct {
 	Region string `json:"region"`
 
 	// +optional
-	IngresIpRanges []string `json:"ingressIpRanges"`
+	IngressIpRanges []string `json:"ingressIpRanges"`
 	// +optional
 	HostUrl string `json:"hostUrl"`
 }

--- a/api/holodeck/v1alpha1/zz_generated.deepcopy.go
+++ b/api/holodeck/v1alpha1/zz_generated.deepcopy.go
@@ -227,8 +227,8 @@ func (in *Image) DeepCopy() *Image {
 func (in *Instance) DeepCopyInto(out *Instance) {
 	*out = *in
 	in.Image.DeepCopyInto(&out.Image)
-	if in.IngresIpRanges != nil {
-		in, out := &in.IngresIpRanges, &out.IngresIpRanges
+	if in.IngressIpRanges != nil {
+		in, out := &in.IngressIpRanges, &out.IngressIpRanges
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,7 +15,8 @@ get started, use, and contribute to Holodeck.
     including coding standards and PR process.
 - [Examples](examples/README.md): Example configuration files and usage scenarios.
 - [Guides](guides/README.md): In-depth guides and tutorials for advanced usage.
-- [IP Detection Guide](guides/ip-detection.md): Learn about automatic IP detection for AWS environments.
+- [IP Detection Guide](guides/ip-detection.md): Learn about automatic IP
+    detection for AWS environments.
 - [Latest Release](https://github.com/NVIDIA/holodeck/releases/latest)
 
 ---

--- a/docs/README.md
+++ b/docs/README.md
@@ -15,6 +15,7 @@ get started, use, and contribute to Holodeck.
     including coding standards and PR process.
 - [Examples](examples/README.md): Example configuration files and usage scenarios.
 - [Guides](guides/README.md): In-depth guides and tutorials for advanced usage.
+- [IP Detection Guide](guides/ip-detection.md): Learn about automatic IP detection for AWS environments.
 - [Latest Release](https://github.com/NVIDIA/holodeck/releases/latest)
 
 ---

--- a/docs/commands/create.md
+++ b/docs/commands/create.md
@@ -56,6 +56,49 @@ spec:
     version: v1.28.5
 ```
 
+## Automated IP Detection
+
+Holodeck now automatically detects your public IP address when creating AWS environments. This eliminates the need to manually specify your IP address in the configuration file.
+
+### How It Works
+
+- **Automatic Detection**: Your public IP is automatically detected using reliable HTTP services
+- **Fallback Services**: Multiple IP detection services ensure reliability (ipify.org, ifconfig.me, icanhazip.com, ident.me)
+- **Proper CIDR Format**: IP addresses are automatically formatted with `/32` suffix for AWS compatibility
+- **Timeout Protection**: 15-second overall timeout with 5-second per-service timeout
+
+### Configuration
+
+The `ingressIpRanges` field in your configuration is now optional for AWS environments:
+
+```yaml
+spec:
+  provider: aws
+  instance:
+    type: g4dn.xlarge
+    region: us-west-2
+    # ingressIpRanges is now optional - your IP is detected automatically
+    # ingressIpRanges:
+    #   - "192.168.1.1/32"  # Only needed for additional IP ranges
+```
+
+### Manual IP Override
+
+If you need to specify additional IP ranges or override the automatic detection, you can still use the `ingressIpRanges` field:
+
+```yaml
+spec:
+  provider: aws
+  instance:
+    type: g4dn.xlarge
+    region: us-west-2
+    ingressIpRanges:
+      - "10.0.0.0/8"      # Corporate network
+      - "172.16.0.0/12"   # Additional network
+```
+
+Your detected public IP will be automatically added to the security group rules.
+
 ## Sample Output
 
 ```text
@@ -68,6 +111,7 @@ Created instance 123e4567-e89b-12d3-a456-426614174000
   invalid.
 - `failed to provision: ...` — Provisioning failed due to a configuration or
   provider error.
+- `error getting IP address: ...` — IP detection failed (check network connectivity to IP detection services).
 - `Created instance <instance-id>` — Success log after creation.
 
 ## Supported NVIDIA Driver Versions

--- a/docs/commands/create.md
+++ b/docs/commands/create.md
@@ -58,14 +58,20 @@ spec:
 
 ## Automated IP Detection
 
-Holodeck now automatically detects your public IP address when creating AWS environments. This eliminates the need to manually specify your IP address in the configuration file.
+Holodeck now automatically detects your public IP address when creating AWS
+environments. This eliminates the need to manually specify your IP address in
+the configuration file.
 
 ### How It Works
 
-- **Automatic Detection**: Your public IP is automatically detected using reliable HTTP services
-- **Fallback Services**: Multiple IP detection services ensure reliability (ipify.org, ifconfig.me, icanhazip.com, ident.me)
-- **Proper CIDR Format**: IP addresses are automatically formatted with `/32` suffix for AWS compatibility
-- **Timeout Protection**: 15-second overall timeout with 5-second per-service timeout
+- **Automatic Detection**: Your public IP is automatically detected using
+  reliable HTTP services
+- **Fallback Services**: Multiple IP detection services ensure reliability
+  (ipify.org, ifconfig.me, icanhazip.com, ident.me)
+- **Proper CIDR Format**: IP addresses are automatically formatted with
+  `/32` suffix for AWS compatibility
+- **Timeout Protection**: 15-second overall timeout with 5-second
+  per-service timeout
 
 ### Configuration
 
@@ -84,7 +90,8 @@ spec:
 
 ### Manual IP Override
 
-If you need to specify additional IP ranges or override the automatic detection, you can still use the `ingressIpRanges` field:
+If you need to specify additional IP ranges or override the automatic
+detection, you can still use the `ingressIpRanges` field:
 
 ```yaml
 spec:
@@ -111,7 +118,8 @@ Created instance 123e4567-e89b-12d3-a456-426614174000
   invalid.
 - `failed to provision: ...` — Provisioning failed due to a configuration or
   provider error.
-- `error getting IP address: ...` — IP detection failed (check network connectivity to IP detection services).
+- `error getting IP address: ...` — IP detection failed (check network
+  connectivity to IP detection services).
 - `Created instance <instance-id>` — Success log after creation.
 
 ## Supported NVIDIA Driver Versions

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -83,7 +83,8 @@ spec:
 
 ### Benefits of Automated IP Detection
 
-- **Simplified Configuration**: No need to manually find and specify your public IP
+- **Simplified Configuration**: No need to manually find and specify your
+  public IP
 - **Dynamic IP Support**: Works with changing IP addresses (DHCP, mobile networks)
 - **Reduced Errors**: Eliminates "CIDR block malformed" errors
 - **Better Security**: Ensures only your current public IP has access

--- a/docs/examples/README.md
+++ b/docs/examples/README.md
@@ -51,6 +51,43 @@ A sample kind cluster configuration for use with the kind installer.
 
 ---
 
+## Updated AWS Examples
+
+The example configurations now show that `ingressIpRanges` is optional:
+
+**File:** [`examples/aws_kubeadm.yaml`](../../examples/aws_kubeadm.yaml)
+
+```yaml
+spec:
+  provider: aws
+  instance:
+    type: g4dn.xlarge
+    region: us-west-2
+    # ingressIpRanges is now optional - your IP is detected automatically
+    image:
+      architecture: amd64
+```
+
+**File:** [`examples/aws_kind.yaml`](../../examples/aws_kind.yaml)
+
+```yaml
+spec:
+  provider: aws
+  instance:
+    type: g4dn.xlarge
+    region: eu-north-1
+    # ingressIpRanges is now optional - your IP is detected automatically
+    image:
+      architecture: amd64
+```
+
+### Benefits of Automated IP Detection
+
+- **Simplified Configuration**: No need to manually find and specify your public IP
+- **Dynamic IP Support**: Works with changing IP addresses (DHCP, mobile networks)
+- **Reduced Errors**: Eliminates "CIDR block malformed" errors
+- **Better Security**: Ensures only your current public IP has access
+
 ## How to Use These Examples
 
 1. Copy the desired YAML file to your working directory (optional).

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -2,9 +2,11 @@
 
 This section is for in-depth guides and tutorials related to Holodeck.
 
-- If you are looking for step-by-step instructions or advanced usage, guides
-    will be listed here as they are added.
-- To contribute a guide, simply add a new Markdown file to this folder and
-    update this README with a link.
+## Available Guides
 
-*No guides are available yet. Stay tuned!*
+- [IP Detection Guide](ip-detection.md): Learn about automatic IP detection for AWS environments, including configuration, troubleshooting, and best practices.
+
+## Contributing
+
+To contribute a guide, simply add a new Markdown file to this folder and
+update this README with a link.

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -4,7 +4,8 @@ This section is for in-depth guides and tutorials related to Holodeck.
 
 ## Available Guides
 
-- [IP Detection Guide](ip-detection.md): Learn about automatic IP detection for AWS environments, including configuration, troubleshooting, and best practices.
+- [IP Detection Guide](ip-detection.md): Learn about automatic IP detection for
+    AWS environments, including configuration, troubleshooting, and best practices.
 
 ## Contributing
 

--- a/docs/guides/ip-detection.md
+++ b/docs/guides/ip-detection.md
@@ -2,16 +2,17 @@
 
 ## Overview
 
-Holodeck automatically detects your public IP address when creating AWS environments, eliminating the need to manually configure security group rules.
+Holodeck automatically detects your public IP address when creating AWS
+environments, eliminating the need to manually configure security group rules.
 
 ## How It Works
 
 ### Detection Process
 
 1. **Service Priority**: Tries multiple IP detection services in order
-2. **Fallback Strategy**: If one service fails, automatically tries the next
-3. **Validation**: Ensures detected IP is a valid public IPv4 address
-4. **CIDR Formatting**: Automatically adds `/32` suffix for AWS compatibility
+1. **Fallback Strategy**: If one service fails, automatically tries the next
+1. **Validation**: Ensures detected IP is a valid public IPv4 address
+1. **CIDR Formatting**: Automatically adds `/32` suffix for AWS compatibility
 
 ### Supported Services
 
@@ -66,8 +67,8 @@ spec:
 ### Common Issues
 
 1. **Network Connectivity**: Ensure outbound internet access to IP detection services
-2. **Firewall Rules**: Corporate firewalls may block IP detection services
-3. **Proxy Configuration**: Proxy settings may affect IP detection
+1. **Firewall Rules**: Corporate firewalls may block IP detection services
+1. **Proxy Configuration**: Proxy settings may affect IP detection
 
 ### Manual Override
 
@@ -100,6 +101,7 @@ curl https://ident.me
 ### IP Validation
 
 The system validates that detected IPs are:
+
 - Valid IPv4 addresses
 - Public (not private, loopback, or link-local)
 - Properly formatted for AWS security groups
@@ -113,9 +115,9 @@ The system validates that detected IPs are:
 ## Best Practices
 
 1. **Use Automatic Detection**: Let Holodeck handle IP detection automatically
-2. **Specify Additional Ranges**: Use `ingressIpRanges` only for additional networks
-3. **Test Connectivity**: Verify access to IP detection services in your environment
-4. **Monitor Changes**: Be aware that your public IP may change (DHCP, mobile networks)
+1. **Specify Additional Ranges**: Use `ingressIpRanges` only for additional networks
+1. **Test Connectivity**: Verify access to IP detection services in your environment
+1. **Monitor Changes**: Be aware that your public IP may change (DHCP, mobile networks)
 
 ## Related Documentation
 

--- a/docs/guides/ip-detection.md
+++ b/docs/guides/ip-detection.md
@@ -1,0 +1,124 @@
+# IP Detection Guide
+
+## Overview
+
+Holodeck automatically detects your public IP address when creating AWS environments, eliminating the need to manually configure security group rules.
+
+## How It Works
+
+### Detection Process
+
+1. **Service Priority**: Tries multiple IP detection services in order
+2. **Fallback Strategy**: If one service fails, automatically tries the next
+3. **Validation**: Ensures detected IP is a valid public IPv4 address
+4. **CIDR Formatting**: Automatically adds `/32` suffix for AWS compatibility
+
+### Supported Services
+
+- `https://api.ipify.org?format=text` (Primary)
+- `https://ifconfig.me/ip` (Fallback 1)
+- `https://icanhazip.com` (Fallback 2)
+- `https://ident.me` (Fallback 3)
+
+### Timeout Configuration
+
+- **Overall Timeout**: 15 seconds
+- **Per-Service Timeout**: 5 seconds
+- **Context Support**: Proper cancellation and timeout handling
+
+## Configuration Examples
+
+### Basic Usage (Recommended)
+
+```yaml
+apiVersion: holodeck.nvidia.com/v1alpha1
+kind: Environment
+metadata:
+  name: my-environment
+spec:
+  provider: aws
+  instance:
+    type: g4dn.xlarge
+    region: us-west-2
+    # No ingressIpRanges needed - IP detected automatically
+```
+
+### With Additional IP Ranges
+
+```yaml
+apiVersion: holodeck.nvidia.com/v1alpha1
+kind: Environment
+metadata:
+  name: my-environment
+spec:
+  provider: aws
+  instance:
+    type: g4dn.xlarge
+    region: us-west-2
+    ingressIpRanges:
+      - "10.0.0.0/8"      # Corporate network
+      - "172.16.0.0/12"   # Additional network
+    # Your detected IP will be automatically added
+```
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Network Connectivity**: Ensure outbound internet access to IP detection services
+2. **Firewall Rules**: Corporate firewalls may block IP detection services
+3. **Proxy Configuration**: Proxy settings may affect IP detection
+
+### Manual Override
+
+If automatic detection fails, you can manually specify your IP:
+
+```yaml
+spec:
+  provider: aws
+  instance:
+    type: g4dn.xlarge
+    region: us-west-2
+    ingressIpRanges:
+      - "YOUR_PUBLIC_IP/32"  # Replace with your actual public IP
+```
+
+### Debugging
+
+To debug IP detection issues:
+
+```bash
+# Test IP detection manually
+curl https://api.ipify.org?format=text
+curl https://ifconfig.me/ip
+curl https://icanhazip.com
+curl https://ident.me
+```
+
+## Security Considerations
+
+### IP Validation
+
+The system validates that detected IPs are:
+- Valid IPv4 addresses
+- Public (not private, loopback, or link-local)
+- Properly formatted for AWS security groups
+
+### Network Security
+
+- Only your current public IP is granted access
+- Additional IP ranges can be specified manually
+- Security group rules are automatically configured
+
+## Best Practices
+
+1. **Use Automatic Detection**: Let Holodeck handle IP detection automatically
+2. **Specify Additional Ranges**: Use `ingressIpRanges` only for additional networks
+3. **Test Connectivity**: Verify access to IP detection services in your environment
+4. **Monitor Changes**: Be aware that your public IP may change (DHCP, mobile networks)
+
+## Related Documentation
+
+- [Create Command](../commands/create.md#automated-ip-detection)
+- [Prerequisites](../prerequisites.md#network-requirements)
+- [Examples](../../examples/README.md#updated-aws-examples)

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -73,9 +73,10 @@ spec:
 
 ## Network Requirements
 
-- Outbound internet access for package downloads
-- Appropriate security group rules for your use case
-- VPC configuration if using AWS provider
+- **Outbound Internet Access**: Required for package downloads and IP detection
+- **IP Detection Services**: Access to public IP detection services (ipify.org, ifconfig.me, icanhazip.com, ident.me)
+- **Security Group Rules**: Automatically configured for your detected public IP
+- **VPC Configuration**: Automatically configured if using AWS provider
 
 ## GPU & Driver Requirements
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -74,7 +74,8 @@ spec:
 ## Network Requirements
 
 - **Outbound Internet Access**: Required for package downloads and IP detection
-- **IP Detection Services**: Access to public IP detection services (ipify.org, ifconfig.me, icanhazip.com, ident.me)
+- **IP Detection Services**: Access to public IP detection services
+  (ipify.org, ifconfig.me, icanhazip.com, ident.me)
 - **Security Group Rules**: Automatically configured for your detected public IP
 - **VPC Configuration**: Automatically configured if using AWS provider
 

--- a/examples/aws_kind.yaml
+++ b/examples/aws_kind.yaml
@@ -11,8 +11,9 @@ spec:
   instance:
     type: g4dn.xlarge
     region: eu-north-1
-    ingressIpRanges:
-      - <MyIP>/<Range>
+    # ingressIpRanges is now optional - your IP is detected automatically
+    # ingressIpRanges:
+    #   - "YOUR_IP/32"  # Only needed for additional IP ranges
     image:
       architecture: amd64
   kubernetes:

--- a/examples/aws_kubeadm.yaml
+++ b/examples/aws_kubeadm.yaml
@@ -11,8 +11,9 @@ spec:
   instance:
     type: g4dn.xlarge
     region: us-west-1
-    ingressIpRanges:
-    - <youip/32>
+    # ingressIpRanges is now optional - your IP is detected automatically
+    # ingressIpRanges:
+    #   - "YOUR_IP/32"  # Only needed for additional IP ranges
     image:
       architecture: amd64
   nvidiaDriver:

--- a/examples/v1alpha1_environment.yaml
+++ b/examples/v1alpha1_environment.yaml
@@ -11,8 +11,9 @@ spec:
   instance:
     type: g4dn.xlarge
     region: eu-north-1
-    ingressIpRanges:
-      - <MyIp>/<Range>
+    # ingressIpRanges is now optional - your IP is detected automatically
+    # ingressIpRanges:
+    #   - "YOUR_IP/32"  # Only needed for additional IP ranges
     image:
       architecture: X86_64
   containerRuntime:

--- a/pkg/provider/aws/create.go
+++ b/pkg/provider/aws/create.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/NVIDIA/holodeck/pkg/utils"
+
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go/aws"

--- a/pkg/provider/aws/create.go
+++ b/pkg/provider/aws/create.go
@@ -21,6 +21,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/NVIDIA/holodeck/pkg/utils"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"
 	"github.com/aws/aws-sdk-go-v2/service/ec2/types"
 	"github.com/aws/aws-sdk-go/aws"
@@ -248,6 +249,17 @@ func (p *Provider) createSecurityGroup(cache *AWS) error {
 
 	// Enter the Ingress rules for the security group
 	ipRanges := []types.IpRange{}
+	// First lookup for the IP address of the user
+	ip, err := utils.GetIPAddress()
+	if err != nil {
+		p.fail()
+		return fmt.Errorf("error getting IP address: %v", err)
+	}
+	ipRanges = append(ipRanges, types.IpRange{
+		CidrIp: &ip,
+	})
+
+	// Then add the IP ranges from the spec
 	for _, ip := range p.Spec.IngresIpRanges {
 		ipRanges = append(ipRanges, types.IpRange{
 			CidrIp: &ip,

--- a/pkg/provider/aws/create.go
+++ b/pkg/provider/aws/create.go
@@ -261,7 +261,7 @@ func (p *Provider) createSecurityGroup(cache *AWS) error {
 	})
 
 	// Then add the IP ranges from the spec
-	for _, ip := range p.Spec.IngresIpRanges {
+	for _, ip := range p.Spec.IngressIpRanges {
 		ipRanges = append(ipRanges, types.IpRange{
 			CidrIp: &ip,
 		})

--- a/pkg/utils/ip.go
+++ b/pkg/utils/ip.go
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ * Copyright (c) 2025, NVIDIA CORPORATION.  All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -75,7 +75,7 @@ func getIPFromHTTPService(ctx context.Context, url string, timeout time.Duration
 	if err != nil {
 		return "", fmt.Errorf("error fetching IP from %s: %v", url, err)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() // nolint:errcheck, gosec, staticcheck
 
 	// Check status code
 	if resp.StatusCode != http.StatusOK {

--- a/pkg/utils/ip.go
+++ b/pkg/utils/ip.go
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2024, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package utils
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"strings"
+	"time"
+)
+
+// GetIPAddress gets the IP address of the user with timeout and fallback services
+func GetIPAddress() (string, error) {
+	// List of IP lookup services to try in order of preference
+	ipServices := []struct {
+		url     string
+		timeout time.Duration
+	}{
+		{"https://api.ipify.org?format=text", 5 * time.Second},
+		{"https://ifconfig.me/ip", 5 * time.Second},
+		{"https://icanhazip.com", 5 * time.Second},
+		{"https://ident.me", 5 * time.Second},
+	}
+
+	// Create context with overall timeout
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	// Try each service until one works
+	for _, service := range ipServices {
+		ip, err := getIPFromHTTPService(ctx, service.url, service.timeout)
+		if err == nil && isValidPublicIP(ip) {
+			return fmt.Sprintf("%s/32", ip), nil
+		}
+	}
+
+	return "", fmt.Errorf("failed to get IP address from all services")
+}
+
+// getIPFromHTTPService attempts to get IP from a specific HTTP service
+func getIPFromHTTPService(ctx context.Context, url string, timeout time.Duration) (string, error) {
+	// Create HTTP client with timeout
+	client := &http.Client{
+		Timeout: timeout,
+	}
+
+	// Create request with context
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
+	if err != nil {
+		return "", fmt.Errorf("error creating request for %s: %v", url, err)
+	}
+
+	// Set user agent to avoid being blocked
+	req.Header.Set("User-Agent", "Holodeck/1.0")
+
+	// Make the request
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("error fetching IP from %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+
+	// Check status code
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("unexpected status from %s: %s", url, resp.Status)
+	}
+
+	// Read response body
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("error reading response from %s: %v", url, err)
+	}
+
+	// Clean the IP address (remove whitespace and newlines)
+	ip := strings.TrimSpace(string(body))
+	if ip == "" {
+		return "", fmt.Errorf("empty response from %s", url)
+	}
+
+	return ip, nil
+}
+
+// isValidPublicIP validates that the IP is a valid public IPv4 address
+func isValidPublicIP(ipStr string) bool {
+	ip := net.ParseIP(ipStr)
+	if ip == nil {
+		return false
+	}
+
+	// Must be IPv4
+	if ip.To4() == nil {
+		return false
+	}
+
+	// Must not be private, loopback, or link-local
+	return !ip.IsPrivate() && !ip.IsLoopback() && !ip.IsLinkLocalUnicast()
+}

--- a/pkg/utils/ip.go
+++ b/pkg/utils/ip.go
@@ -68,7 +68,7 @@ func getIPFromHTTPService(ctx context.Context, url string, timeout time.Duration
 	}
 
 	// Set user agent to avoid being blocked
-	req.Header.Set("User-Agent", "Holodeck/1.0")
+	req.Header.Set("User-Agent", "Holodeck")
 
 	// Make the request
 	resp, err := client.Do(req)

--- a/tests/aws_test.go
+++ b/tests/aws_test.go
@@ -103,7 +103,6 @@ var _ = DescribeTable("AWS Environment E2E",
 		Expect(provisioner.Dryrun(state.log, state.opts.cfg)).To(Succeed(), "Provisioner validation failed")
 		Expect(state.opts.cfg.Spec.Instance.Type).NotTo(BeEmpty(), "Instance type should not be empty")
 		Expect(state.opts.cfg.Spec.Instance.Region).NotTo(BeEmpty(), "Region should not be empty")
-		Expect(state.opts.cfg.Spec.Instance.IngresIpRanges).NotTo(BeEmpty(), "Ingress IP ranges should not be empty")
 
 		By("Environment Management")
 		// Ensure environment cleanup even if test fails

--- a/tests/data/test_aws.yml
+++ b/tests/data/test_aws.yml
@@ -11,13 +11,6 @@ spec:
   instance:
     type: g4dn.xlarge
     region: us-west-1
-    ingressIpRanges:
-    - 18.190.12.32/32
-    - 3.143.46.93/32
-    - 44.230.241.223/32
-    - 44.235.4.62/32
-    - 52.15.119.136/32
-    - 52.24.205.48/32
     image:
       architecture: amd64
   containerRuntime:

--- a/tests/data/test_aws_dra.yml
+++ b/tests/data/test_aws_dra.yml
@@ -11,13 +11,6 @@ spec:
   instance:
     type: m4.xlarge
     region: us-west-1
-    ingressIpRanges:
-    - 18.190.12.32/32
-    - 3.143.46.93/32
-    - 44.230.241.223/32
-    - 44.235.4.62/32
-    - 52.15.119.136/32
-    - 52.24.205.48/32
     image:
       architecture: amd64
   containerRuntime:

--- a/tests/data/test_aws_kernel.yml
+++ b/tests/data/test_aws_kernel.yml
@@ -11,13 +11,6 @@ spec:
   instance:
     type: g4dn.xlarge
     region: us-west-1
-    ingressIpRanges:
-    - 18.190.12.32/32
-    - 3.143.46.93/32
-    - 44.230.241.223/32
-    - 44.235.4.62/32
-    - 52.15.119.136/32
-    - 52.24.205.48/32
     image:
       architecture: amd64
   kernel:

--- a/tests/data/test_aws_legacy.yml
+++ b/tests/data/test_aws_legacy.yml
@@ -11,13 +11,6 @@ spec:
   instance:
     type: m4.xlarge
     region: us-west-1
-    ingressIpRanges:
-    - 18.190.12.32/32
-    - 3.143.46.93/32
-    - 44.230.241.223/32
-    - 44.235.4.62/32
-    - 52.15.119.136/32
-    - 52.24.205.48/32
     image:
       architecture: amd64
   containerRuntime:


### PR DESCRIPTION
This pull request introduces automated public IP detection for AWS environments in Holodeck, simplifying configuration and improving usability. The changes include updates to documentation, examples, and the codebase to support this new feature. Below is a summary of the most important changes:

### Feature Implementation:
* Added the `GetIPAddress` utility function to automatically detect the user's public IP using multiple fallback services and format it in CIDR notation for AWS compatibility. (`pkg/utils/ip.go`, [pkg/utils/ip.goR1-R114](diffhunk://#diff-75bfb3a5a68e8a74ce4ce207e14accf70a6ed4dd9d50b91ff98477f03b574022R1-R114))
* Integrated the IP detection functionality into the AWS provider's security group creation process, ensuring the detected IP is added to the security group rules. (`pkg/provider/aws/create.go`, [pkg/provider/aws/create.goR252-R262](diffhunk://#diff-8f67351bcb451f97fd46b094688154100f0da0e602b6ffe767fe6eff0a8dc5f7R252-R262))

### Documentation Updates:
* Added a new "IP Detection Guide" with detailed explanations of the feature, configuration examples, troubleshooting steps, and best practices. (`docs/guides/ip-detection.md`, [docs/guides/ip-detection.mdR1-R124](diffhunk://#diff-1869de6be8431724764ded2908f73633d26c73b52bfe040e2504d28cfe3c4ac7R1-R124))
* Updated existing documentation to reflect the new behavior, including the `README.md`, `commands/create.md`, `guides/README.md`, and `prerequisites.md` files. (`docs/README.md`, [[1]](diffhunk://#diff-0b5ca119d2be595aa307d34512d9679e49186307ef94201e4b3dfa079aa89938R18); `docs/commands/create.md`, [[2]](diffhunk://#diff-0e9c81909d3a6685834f43a69556f29c55b88ed0ce1d9bb10e6dabdc6d7f9e2fR59-R101); `docs/guides/README.md`, [[3]](diffhunk://#diff-8d80745b4e642475274e1de3100d73869664e9ed435af8f839eff86b39acbbedL5-R12); `docs/prerequisites.md`, [[4]](diffhunk://#diff-62bb42a945e73c6607642b8ca0b796633542e7491d6661520a311e943f313806L76-R79)

### Example Configuration Updates:
* Modified example YAML files to indicate that the `ingressIpRanges` field is now optional, as the user's public IP is automatically detected. (`examples/aws_kind.yaml`, [[1]](diffhunk://#diff-7505e9da5e2bc049fe7cacf6d6c302e4a5eb31e6f49f27adcc48cab68c431f4cL14-R16); `examples/aws_kubeadm.yaml`, [[2]](diffhunk://#diff-1561a9e7398d3c491a26e3d6e526b296dd2b060567b18c7ee9ccea6a413cdfd7L14-R16); `examples/v1alpha1_environment.yaml`, [[3]](diffhunk://#diff-e9b20dac212459b659e16c783674917054752b95d097f32e060151271f095104L14-R16)

### Test Data Updates:
* Removed hardcoded `ingressIpRanges` entries from test data files to align with the new automated IP detection feature. (`tests/data/test_aws.yml`, [[1]](diffhunk://#diff-d6b8a7525a045b9eb074dacb8575e9b4945bdadd5685121599a8dc0f829fd857L14-L20); `tests/data/test_aws_dra.yml`, [[2]](diffhunk://#diff-3b002587460697f314961505f2cd1d6f925524955db01955f5c303d806f36f6eL14-L20); `tests/data/test_aws_kernel.yml`, [[3]](diffhunk://#diff-4d2a94465b6e054e9d6bb447e508143376e886ccc84a786d7876de6c76923b80L14-L20); `tests/data/test_aws_legacy.yml`, [[4]](diffhunk://#diff-a583ba72cbcf88e40a0df4d305d9bb8d1c91bfeb23d399e414a77d4396de1c0cL14-L20)

These changes collectively enhance the user experience by automating IP configuration for AWS environments, reducing errors, and improving documentation clarity.