### PR TITLE
[no-relnote] Add E2E CI Pipeline status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Latest Release](https://img.shields.io/github/v/release/NVIDIA/holodeck?label=latest%20release)](https://github.com/NVIDIA/holodeck/releases/latest)
 
+[![CI Pipeline](https://github.com/NVIDIA/holodeck/actions/workflows/ci.yaml/badge.svg?branch=main)](https://github.com/NVIDIA/holodeck/actions/workflows/ci.yaml)
+
 A tool for creating and managing GPU-ready Cloud test environments.
 
 ---


### PR DESCRIPTION
This pull request includes a small update to the `README.md` file. The change adds a badge for the CI pipeline status, linking to the workflow on the `main` branch.