### PR TITLE
Rever commit version bump on aws-actions/configure-aws-credentials

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up AWS CLI
-        uses: aws-actions/configure-aws-credentials@v6
+        uses: aws-actions/configure-aws-credentials@v5
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
## Description

Dependabot bumped this dependency back in october, but now the project `aws-actions/configure-aws-credentials` doesn't show a v6 release, we need to rollback this version bump

## Motivation

<!-- Why is this change needed? Link to related issues if applicable -->

Fixes #<!-- issue number -->

## Type of Change

<!-- Mark the relevant option with an [x] -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🧪 Test improvements
- [ ] 🔨 Build/CI changes

## Changes Made

<!-- List the specific changes made in this PR -->

- 
- 
- 

## Testing

<!-- Describe the testing performed -->

- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Manual testing performed

### Test Commands Run

```bash
# Commands used to test the changes
make test
make lint
```

## Checklist

- [ ] My code follows the project's coding conventions
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] I have updated the documentation (if applicable)
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix/feature works
- [ ] New and existing tests pass locally
- [ ] I have signed off my commits (`git commit -s`)

## Additional Notes

<!-- Any additional information that reviewers should know -->

