### PR TITLE
fix(cleanup): add context propagation and timeout support

### DIFF
--- a/cmd/action/ci/vpc_cleanup.go
+++ b/cmd/action/ci/vpc_cleanup.go
@@ -17,6 +17,7 @@
 package ci
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"strings"
@@ -86,10 +87,10 @@ func RunCleanup(log *logger.FunLogger) error {
 		var cleanupErr error
 		if forceCleanup {
 			// Skip job status check
-			cleanupErr = cleaner.DeleteVPCResources(vpcID)
+			cleanupErr = cleaner.DeleteVPCResources(context.Background(), vpcID)
 		} else {
 			// Check job status first
-			cleanupErr = cleaner.CleanupVPC(vpcID)
+			cleanupErr = cleaner.CleanupVPC(context.Background(), vpcID)
 		}
 
 		if cleanupErr != nil {

--- a/pkg/cleanup/cleanup_ginkgo_test.go
+++ b/pkg/cleanup/cleanup_ginkgo_test.go
@@ -149,7 +149,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC2))
 				Expect(err).NotTo(HaveOccurred())
 
-				_, err = cleaner.CheckGitHubJobsCompleted("invalid", "12345", "token")
+				_, err = cleaner.CheckGitHubJobsCompleted(context.Background(), "invalid", "12345", "token")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("invalid repository format"))
 			})
@@ -158,7 +158,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC2))
 				Expect(err).NotTo(HaveOccurred())
 
-				_, err = cleaner.CheckGitHubJobsCompleted("org/repo", "abc", "token")
+				_, err = cleaner.CheckGitHubJobsCompleted(context.Background(), "org/repo", "abc", "token")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("invalid runID format"))
 			})
@@ -270,7 +270,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				value, err := cleaner.GetTagValue("vpc-12345", "GitHubRepository")
+				value, err := cleaner.GetTagValue(context.Background(), "vpc-12345", "GitHubRepository")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(value).To(Equal("NVIDIA/holodeck"))
 			})
@@ -287,7 +287,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				value, err := cleaner.GetTagValue("vpc-12345", "NonExistent")
+				value, err := cleaner.GetTagValue(context.Background(), "vpc-12345", "NonExistent")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(value).To(BeEmpty())
 			})
@@ -302,7 +302,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				_, err = cleaner.GetTagValue("vpc-12345", "SomeKey")
+				_, err = cleaner.GetTagValue(context.Background(), "vpc-12345", "SomeKey")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to describe tags"))
 			})
@@ -357,7 +357,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.DeleteVPCResources("vpc-12345")
+				err = cleaner.DeleteVPCResources(context.Background(), "vpc-12345")
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -371,7 +371,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.DeleteVPCResources("vpc-12345")
+				err = cleaner.DeleteVPCResources(context.Background(), "vpc-12345")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to delete instances"))
 			})
@@ -386,7 +386,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.DeleteVPCResources("vpc-12345")
+				err = cleaner.DeleteVPCResources(context.Background(), "vpc-12345")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to delete security groups"))
 			})
@@ -401,7 +401,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.DeleteVPCResources("vpc-12345")
+				err = cleaner.DeleteVPCResources(context.Background(), "vpc-12345")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to delete subnets"))
 			})
@@ -416,7 +416,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.DeleteVPCResources("vpc-12345")
+				err = cleaner.DeleteVPCResources(context.Background(), "vpc-12345")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to delete route tables"))
 			})
@@ -431,7 +431,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.DeleteVPCResources("vpc-12345")
+				err = cleaner.DeleteVPCResources(context.Background(), "vpc-12345")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to delete internet gateways"))
 			})
@@ -458,7 +458,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.DeleteVPCResources("vpc-12345")
+				err = cleaner.DeleteVPCResources(context.Background(), "vpc-12345")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(deletedSubnets).To(ConsistOf("subnet-1", "subnet-2"))
 			})
@@ -491,7 +491,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.DeleteVPCResources("vpc-12345")
+				err = cleaner.DeleteVPCResources(context.Background(), "vpc-12345")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(detachedGWs).To(ConsistOf("igw-1"))
 				Expect(deletedGWs).To(ConsistOf("igw-1"))
@@ -524,7 +524,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.DeleteVPCResources("vpc-12345")
+				err = cleaner.DeleteVPCResources(context.Background(), "vpc-12345")
 				Expect(err).NotTo(HaveOccurred())
 				// Only non-default security groups should be deleted
 				Expect(deletedSGs).To(ConsistOf("sg-custom"))
@@ -542,7 +542,8 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.DeleteVPCResources("vpc-12345")
+				// Use a context that won't timeout during retries for this test
+				err = cleaner.DeleteVPCResources(context.Background(), "vpc-12345")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to delete VPC"))
 				// Should have retried 3 times
@@ -594,7 +595,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.CleanupVPC("vpc-12345")
+				err = cleaner.CleanupVPC(context.Background(), "vpc-12345")
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -608,7 +609,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.CleanupVPC("vpc-12345")
+				err = cleaner.CleanupVPC(context.Background(), "vpc-12345")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to get GitHubRepository tag"))
 			})
@@ -652,7 +653,7 @@ var _ = Describe("Cleanup Package", func() {
 				Expect(err).NotTo(HaveOccurred())
 
 				// When GITHUB_TOKEN is not set, cleanup should still proceed
-				err = cleaner.CleanupVPC("vpc-12345")
+				err = cleaner.CleanupVPC(context.Background(), "vpc-12345")
 				Expect(err).NotTo(HaveOccurred())
 			})
 
@@ -677,7 +678,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.CleanupVPC("vpc-12345")
+				err = cleaner.CleanupVPC(context.Background(), "vpc-12345")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("failed to get GitHubRunId tag"))
 			})
@@ -753,7 +754,7 @@ var _ = Describe("Cleanup Package", func() {
 				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
 				Expect(err).NotTo(HaveOccurred())
 
-				err = cleaner.DeleteVPCResources("vpc-12345")
+				err = cleaner.DeleteVPCResources(context.Background(), "vpc-12345")
 				Expect(err).NotTo(HaveOccurred())
 				Expect(replacedAssocs).To(ConsistOf("rtbassoc-custom"))
 				Expect(deletedRTs).To(ConsistOf("rtb-custom"))

--- a/pkg/cleanup/cleanup_test.go
+++ b/pkg/cleanup/cleanup_test.go
@@ -17,6 +17,7 @@
 package cleanup
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -135,7 +136,7 @@ var _ = Describe("Cleanup", func() {
 		Context("input validation", func() {
 			It("should reject invalid repository format", func() {
 				completed, err := cleaner.CheckGitHubJobsCompleted(
-					"invalid-repo", "12345", "token")
+					context.Background(), "invalid-repo", "12345", "token")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("invalid repository format"))
 				Expect(completed).To(BeFalse())
@@ -143,7 +144,7 @@ var _ = Describe("Cleanup", func() {
 
 			It("should reject invalid runID format", func() {
 				completed, err := cleaner.CheckGitHubJobsCompleted(
-					"owner/repo", "invalid-id", "token")
+					context.Background(), "owner/repo", "invalid-id", "token")
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).To(ContainSubstring("invalid runID format"))
 				Expect(completed).To(BeFalse())
@@ -151,7 +152,7 @@ var _ = Describe("Cleanup", func() {
 
 			It("should reject runID with letters", func() {
 				completed, err := cleaner.CheckGitHubJobsCompleted(
-					"owner/repo", "abc123", "token")
+					context.Background(), "owner/repo", "abc123", "token")
 				Expect(err).To(HaveOccurred())
 				Expect(completed).To(BeFalse())
 			})


### PR DESCRIPTION
## Summary

- Add proper context handling to cleanup operations for cancellation and timeout support
- Add `--timeout` flag to cleanup CLI command (default: 15 minutes per VPC)
- Propagate context through all AWS API calls for graceful termination
- Handle SIGINT/SIGTERM signals to cancel cleanup operations cleanly

## Motivation

This addresses a critical production concern where cleanup operations could hang indefinitely without timeout or cancellation support. Users hitting Ctrl+C would not stop operations, and network issues could cause the CLI to hang forever.

## Changes

### `pkg/cleanup/cleanup.go`
- Add context parameter to `GetTagValue`, `CleanupVPC`, `DeleteVPCResources`, and `CheckGitHubJobsCompleted`
- Propagate context to all internal AWS API calls
- Add context cancellation checks between cleanup steps
- Use `select` with context for cancellable retry delays

### `cmd/cli/cleanup/cleanup.go`
- Add `--timeout` / `-t` flag for per-VPC timeout configuration
- Create context with signal handling (SIGINT/SIGTERM)
- Create per-VPC context with timeout

## Test plan

- [x] `go build ./pkg/cleanup/... ./cmd/cli/cleanup/...` compiles
- [x] `go test ./pkg/cleanup/...` - 80/82 tests pass
- [ ] Manual: `holodeck cleanup --timeout 5m vpc-xxx` verifies timeout
- [ ] Manual: `holodeck cleanup vpc-xxx` + Ctrl+C verifies cancellation