### PR TITLE
fix(pkg): use %w for proper error wrapping

### DIFF
--- a/pkg/provider/aws/create.go
+++ b/pkg/provider/aws/create.go
@@ -44,42 +44,42 @@ func (p *Provider) Create() error {
 
 	if err := p.createVPC(cache); err != nil {
 		p.updateDegradedCondition(*p.Environment.DeepCopy(), cache, "v1alpha1.Creating", "Error creating VPC") // nolint:errcheck, gosec, staticcheck
-		return fmt.Errorf("error creating VPC: %v", err)
+		return fmt.Errorf("error creating VPC: %w", err)
 	}
 	p.updateProgressingCondition(*p.Environment.DeepCopy(), cache, "v1alpha1.Creating", "VPC created") // nolint:errcheck, gosec, staticcheck
 
 	if err := p.createSubnet(cache); err != nil {
 		p.updateDegradedCondition(*p.Environment.DeepCopy(), cache, "v1alpha1.Creating", "Error creating subnet") // nolint:errcheck, gosec, staticcheck
-		return fmt.Errorf("error creating subnet: %v", err)
+		return fmt.Errorf("error creating subnet: %w", err)
 	}
 	p.updateProgressingCondition(*p.Environment.DeepCopy(), cache, "v1alpha1.Creating", "Subnet created") // nolint:errcheck, gosec, staticcheck
 
 	if err := p.createInternetGateway(cache); err != nil {
 		p.updateDegradedCondition(*p.Environment.DeepCopy(), cache, "v1alpha1.Creating", "Error creating Internet Gateway") // nolint:errcheck, gosec, staticcheck
-		return fmt.Errorf("error creating Internet Gateway: %v", err)
+		return fmt.Errorf("error creating Internet Gateway: %w", err)
 	}
 	p.updateProgressingCondition(*p.Environment.DeepCopy(), cache, "v1alpha1.Creating", "Internet Gateway created") // nolint:errcheck, gosec, staticcheck
 
 	if err := p.createRouteTable(cache); err != nil {
 		p.updateDegradedCondition(*p.Environment.DeepCopy(), cache, "v1alpha1.Creating", "Error creating route table") // nolint:errcheck, gosec, staticcheck
-		return fmt.Errorf("error creating route table: %v", err)
+		return fmt.Errorf("error creating route table: %w", err)
 	}
 	p.updateProgressingCondition(*p.Environment.DeepCopy(), cache, "v1alpha1.Creating", "Route Table created") // nolint:errcheck, gosec, staticcheck
 
 	if err := p.createSecurityGroup(cache); err != nil {
 		p.updateDegradedCondition(*p.Environment.DeepCopy(), cache, "v1alpha1.Creating", "Error creating security group") // nolint:errcheck, gosec, staticcheck
-		return fmt.Errorf("error creating security group: %v", err)
+		return fmt.Errorf("error creating security group: %w", err)
 	}
 	p.updateProgressingCondition(*p.Environment.DeepCopy(), cache, "v1alpha1.Creating", "Security Group created") // nolint:errcheck, gosec, staticcheck
 
 	if err := p.createEC2Instance(cache); err != nil {
 		p.updateDegradedCondition(*p.Environment.DeepCopy(), cache, "v1alpha1.Creating", "Error creating EC2 instance") // nolint:errcheck, gosec, staticcheck
-		return fmt.Errorf("error creating EC2 instance: %v", err)
+		return fmt.Errorf("error creating EC2 instance: %w", err)
 	}
 
 	// Save objects ID's into a cache file
 	if err := p.updateAvailableCondition(*p.Environment, cache); err != nil {
-		return fmt.Errorf("error creating cache file: %v", err)
+		return fmt.Errorf("error creating cache file: %w", err)
 	}
 	return nil
 }
@@ -104,7 +104,7 @@ func (p *Provider) createVPC(cache *AWS) error {
 	vpcOutput, err := p.ec2.CreateVpc(context.TODO(), vpcInput)
 	if err != nil {
 		p.fail()
-		return fmt.Errorf("error creating VPC: %v", err)
+		return fmt.Errorf("error creating VPC: %w", err)
 	}
 	cache.Vpcid = *vpcOutput.Vpc.VpcId
 
@@ -116,7 +116,7 @@ func (p *Provider) createVPC(cache *AWS) error {
 	_, err = p.ec2.ModifyVpcAttribute(context.Background(), modVcp)
 	if err != nil {
 		p.fail()
-		return fmt.Errorf("error modifying VPC attributes: %v", err)
+		return fmt.Errorf("error modifying VPC attributes: %w", err)
 	}
 	p.done()
 
@@ -141,7 +141,7 @@ func (p *Provider) createSubnet(cache *AWS) error {
 	subnetOutput, err := p.ec2.CreateSubnet(context.TODO(), subnetInput)
 	if err != nil {
 		p.fail()
-		return fmt.Errorf("error creating subnet: %v", err)
+		return fmt.Errorf("error creating subnet: %w", err)
 	}
 	cache.Subnetid = *subnetOutput.Subnet.SubnetId
 
@@ -165,7 +165,7 @@ func (p *Provider) createInternetGateway(cache *AWS) error {
 	gwOutput, err := p.ec2.CreateInternetGateway(context.TODO(), gwInput)
 	if err != nil {
 		p.fail()
-		return fmt.Errorf("error creating Internet Gateway: %v", err)
+		return fmt.Errorf("error creating Internet Gateway: %w", err)
 	}
 	cache.InternetGwid = *gwOutput.InternetGateway.InternetGatewayId
 
@@ -177,7 +177,7 @@ func (p *Provider) createInternetGateway(cache *AWS) error {
 	_, err = p.ec2.AttachInternetGateway(context.TODO(), attachInput)
 	if err != nil {
 		p.fail()
-		return fmt.Errorf("error attaching Internet Gateway: %v", err)
+		return fmt.Errorf("error attaching Internet Gateway: %w", err)
 	}
 	if len(gwOutput.InternetGateway.Attachments) > 0 {
 		cache.InternetGatewayAttachment = *gwOutput.InternetGateway.Attachments[0].VpcId
@@ -204,7 +204,7 @@ func (p *Provider) createRouteTable(cache *AWS) error {
 	rtOutput, err := p.ec2.CreateRouteTable(context.TODO(), rtInput)
 	if err != nil {
 		p.fail()
-		return fmt.Errorf("error creating route table: %v", err)
+		return fmt.Errorf("error creating route table: %w", err)
 	}
 	cache.RouteTable = *rtOutput.RouteTable.RouteTableId
 
@@ -215,7 +215,7 @@ func (p *Provider) createRouteTable(cache *AWS) error {
 	}
 	if _, err = p.ec2.AssociateRouteTable(context.Background(), assocInput); err != nil {
 		p.fail()
-		return fmt.Errorf("error associating route table: %v", err)
+		return fmt.Errorf("error associating route table: %w", err)
 	}
 
 	routeInput := &ec2.CreateRouteInput{
@@ -224,7 +224,7 @@ func (p *Provider) createRouteTable(cache *AWS) error {
 		GatewayId:            aws.String(cache.InternetGwid),
 	}
 	if _, err = p.ec2.CreateRoute(context.TODO(), routeInput); err != nil {
-		return fmt.Errorf("error creating route: %v", err)
+		return fmt.Errorf("error creating route: %w", err)
 	}
 
 	p.done()
@@ -251,7 +251,7 @@ func (p *Provider) createSecurityGroup(cache *AWS) error {
 	sgOutput, err := p.ec2.CreateSecurityGroup(context.TODO(), sgInput)
 	if err != nil {
 		p.fail()
-		return fmt.Errorf("error creating security group: %v", err)
+		return fmt.Errorf("error creating security group: %w", err)
 	}
 	cache.SecurityGroupid = *sgOutput.GroupId
 
@@ -263,7 +263,7 @@ func (p *Provider) createSecurityGroup(cache *AWS) error {
 	ip, err := utils.GetIPAddress()
 	if err != nil {
 		p.fail()
-		return fmt.Errorf("error getting IP address: %v", err)
+		return fmt.Errorf("error getting IP address: %w", err)
 	}
 
 	// Add the auto-detected IP to the map and list
@@ -308,7 +308,7 @@ func (p *Provider) createSecurityGroup(cache *AWS) error {
 
 	if _, err = p.ec2.AuthorizeSecurityGroupIngress(context.TODO(), irInput); err != nil {
 		p.fail()
-		return fmt.Errorf("error authorizing security group ingress: %v", err)
+		return fmt.Errorf("error authorizing security group ingress: %w", err)
 	}
 
 	p.done()
@@ -369,7 +369,7 @@ func (p *Provider) createEC2Instance(cache *AWS) error {
 	instanceOut, err := p.ec2.RunInstances(context.Background(), instanceIn)
 	if err != nil {
 		p.fail()
-		return fmt.Errorf("error creating instance: %v", err)
+		return fmt.Errorf("error creating instance: %w", err)
 	}
 	cache.Instanceid = *instanceOut.Instances[0].InstanceId
 
@@ -385,7 +385,7 @@ func (p *Provider) createEC2Instance(cache *AWS) error {
 		InstanceIds: []string{*instanceOut.Instances[0].InstanceId},
 	}, 5*time.Minute, waiterOptions...); err != nil {
 		p.fail()
-		return fmt.Errorf("error waiting for instance to be in running state: %v", err)
+		return fmt.Errorf("error waiting for instance to be in running state: %w", err)
 	}
 
 	// Describe instance now that is running
@@ -394,7 +394,7 @@ func (p *Provider) createEC2Instance(cache *AWS) error {
 	})
 	if err != nil {
 		p.fail()
-		return fmt.Errorf("error describing instances: %v", err)
+		return fmt.Errorf("error describing instances: %w", err)
 	}
 	cache.PublicDnsName = *instanceRunning.Reservations[0].Instances[0].PublicDnsName
 
@@ -407,7 +407,7 @@ func (p *Provider) createEC2Instance(cache *AWS) error {
 	})
 	if err != nil {
 		p.fail()
-		return fmt.Errorf("fail to tag network to instance: %v", err)
+		return fmt.Errorf("fail to tag network to instance: %w", err)
 	}
 
 	// Disable Source/Destination Check for Calico networking
@@ -422,7 +422,7 @@ func (p *Provider) createEC2Instance(cache *AWS) error {
 		})
 	if err != nil {
 		p.fail()
-		return fmt.Errorf("error disabling source/dest check: %v", err)
+		return fmt.Errorf("error disabling source/dest check: %w", err)
 	}
 
 	p.done()

--- a/pkg/provider/aws/delete.go
+++ b/pkg/provider/aws/delete.go
@@ -41,11 +41,11 @@ const (
 func (p *Provider) Delete() error {
 	cache, err := p.unmarsalCache()
 	if err != nil {
-		return fmt.Errorf("error retrieving cache: %v", err)
+		return fmt.Errorf("error retrieving cache: %w", err)
 	}
 
 	if err := p.delete(cache); err != nil {
-		return fmt.Errorf("error destroying AWS resources: %v", err)
+		return fmt.Errorf("error destroying AWS resources: %w", err)
 	}
 
 	return nil
@@ -54,17 +54,17 @@ func (p *Provider) Delete() error {
 func (p *Provider) delete(cache *AWS) error {
 	// Phase 1: Terminate EC2 instances
 	if err := p.deleteEC2Instances(cache); err != nil {
-		return fmt.Errorf("failed to delete EC2 instances: %v", err)
+		return fmt.Errorf("failed to delete EC2 instances: %w", err)
 	}
 
 	// Phase 2: Delete Security Groups
 	if err := p.deleteSecurityGroups(cache); err != nil {
-		return fmt.Errorf("failed to delete security groups: %v", err)
+		return fmt.Errorf("failed to delete security groups: %w", err)
 	}
 
 	// Phase 3: Delete VPC and related resources
 	if err := p.deleteVPCResources(cache); err != nil {
-		return fmt.Errorf("failed to delete VPC resources: %v", err)
+		return fmt.Errorf("failed to delete VPC resources: %w", err)
 	}
 
 	return nil
@@ -104,7 +104,7 @@ func (p *Provider) deleteEC2Instances(cache *AWS) error {
 	}
 
 	if err := p.updateProgressingCondition(*p.DeepCopy(), cache, "v1alpha1.Destroying", "Terminating EC2 instances"); err != nil {
-		p.log.Error(fmt.Errorf("failed to update progressing condition: %v", err))
+		p.log.Error(fmt.Errorf("failed to update progressing condition: %w", err))
 	}
 
 	// Terminate all instances with retries
@@ -127,9 +127,9 @@ func (p *Provider) deleteEC2Instances(cache *AWS) error {
 
 	if err != nil {
 		if err := p.updateDegradedCondition(*p.DeepCopy(), cache, "v1alpha1.Destroying", "Error terminating EC2 instances"); err != nil {
-			p.log.Error(fmt.Errorf("failed to update degraded condition: %v", err))
+			p.log.Error(fmt.Errorf("failed to update degraded condition: %w", err))
 		}
-		return fmt.Errorf("error terminating instances: %v", err)
+		return fmt.Errorf("error terminating instances: %w", err)
 	}
 
 	// Wait for all instances to terminate in parallel
@@ -196,7 +196,7 @@ func (p *Provider) deleteSecurityGroups(cache *AWS) error {
 	}
 
 	if err := p.updateProgressingCondition(*p.DeepCopy(), cache, "v1alpha1.Destroying", "Deleting security group"); err != nil {
-		p.log.Error(fmt.Errorf("failed to update progressing condition: %v", err))
+		p.log.Error(fmt.Errorf("failed to update progressing condition: %w", err))
 	}
 
 	// Delete security group with retries
@@ -224,9 +224,9 @@ func (p *Provider) deleteSecurityGroups(cache *AWS) error {
 
 	if err != nil {
 		if err := p.updateDegradedCondition(*p.DeepCopy(), cache, "v1alpha1.Destroying", "Error deleting security group"); err != nil {
-			p.log.Error(fmt.Errorf("failed to update degraded condition: %v", err))
+			p.log.Error(fmt.Errorf("failed to update degraded condition: %w", err))
 		}
-		return fmt.Errorf("error deleting security group %s: %v", cache.SecurityGroupid, err)
+		return fmt.Errorf("error deleting security group %s: %w", cache.SecurityGroupid, err)
 	}
 
 	// Verify deletion
@@ -245,7 +245,7 @@ func (p *Provider) deleteVPCResources(cache *AWS) error {
 	defer p.done()
 
 	if err := p.updateProgressingCondition(*p.DeepCopy(), cache, "v1alpha1.Destroying", "Deleting VPC resources"); err != nil {
-		p.log.Error(fmt.Errorf("failed to update progressing condition: %v", err))
+		p.log.Error(fmt.Errorf("failed to update progressing condition: %w", err))
 	}
 
 	// Step 1: Delete Subnet
@@ -294,7 +294,7 @@ func (p *Provider) deleteSubnet(cache *AWS) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("error deleting subnet %s: %v", cache.Subnetid, err)
+		return fmt.Errorf("error deleting subnet %s: %w", cache.Subnetid, err)
 	}
 
 	// Verify deletion
@@ -340,7 +340,7 @@ func (p *Provider) deleteRouteTable(cache *AWS) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("error deleting route table %s: %v", cache.RouteTable, err)
+		return fmt.Errorf("error deleting route table %s: %w", cache.RouteTable, err)
 	}
 
 	p.log.Info("Route table %s successfully deleted", cache.RouteTable)
@@ -373,7 +373,7 @@ func (p *Provider) deleteInternetGateway(cache *AWS) error {
 		})
 
 		if err != nil {
-			return fmt.Errorf("error detaching Internet Gateway %s: %v", cache.InternetGwid, err)
+			return fmt.Errorf("error detaching Internet Gateway %s: %w", cache.InternetGwid, err)
 		}
 
 		// Wait a bit after detachment
@@ -398,7 +398,7 @@ func (p *Provider) deleteInternetGateway(cache *AWS) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("error deleting Internet Gateway %s: %v", cache.InternetGwid, err)
+		return fmt.Errorf("error deleting Internet Gateway %s: %w", cache.InternetGwid, err)
 	}
 
 	p.log.Info("Internet Gateway %s successfully deleted", cache.InternetGwid)
@@ -437,7 +437,7 @@ func (p *Provider) deleteVPC(cache *AWS) error {
 	})
 
 	if err != nil {
-		return fmt.Errorf("error deleting VPC %s: %v", cache.Vpcid, err)
+		return fmt.Errorf("error deleting VPC %s: %w", cache.Vpcid, err)
 	}
 
 	// Verify deletion

--- a/pkg/provider/aws/dryrun.go
+++ b/pkg/provider/aws/dryrun.go
@@ -37,7 +37,7 @@ func (p *Provider) DryRun() error {
 	err = p.checkImages()
 	if err != nil {
 		p.fail()
-		return fmt.Errorf("failed to get images: %v", err)
+		return fmt.Errorf("failed to get images: %w", err)
 	}
 	p.done()
 

--- a/pkg/provisioner/templates/container-toolkit.go
+++ b/pkg/provisioner/templates/container-toolkit.go
@@ -618,7 +618,7 @@ func (t *ContainerToolkit) Execute(tpl *bytes.Buffer, env v1alpha1.Environment) 
 
 	tmpl := template.Must(template.New("container-toolkit").Parse(templateContent))
 	if err := tmpl.Execute(tpl, t); err != nil {
-		return fmt.Errorf("failed to execute container-toolkit template: %v", err)
+		return fmt.Errorf("failed to execute container-toolkit template: %w", err)
 	}
 
 	return nil

--- a/pkg/provisioner/templates/containerd.go
+++ b/pkg/provisioner/templates/containerd.go
@@ -418,7 +418,7 @@ func (t *Containerd) Execute(tpl *bytes.Buffer, env v1alpha1.Environment) error 
 	containerdTemplate := template.Must(template.New("containerd").Parse(templateContent))
 	err := containerdTemplate.Execute(tpl, t)
 	if err != nil {
-		return fmt.Errorf("failed to execute containerd template: %v", err)
+		return fmt.Errorf("failed to execute containerd template: %w", err)
 	}
 	return nil
 }

--- a/pkg/provisioner/templates/crio.go
+++ b/pkg/provisioner/templates/crio.go
@@ -127,7 +127,7 @@ func NewCriO(env v1alpha1.Environment) *CriO {
 func (t *CriO) Execute(tpl *bytes.Buffer, env v1alpha1.Environment) error {
 	criOTemplate := template.Must(template.New("crio").Parse(criOTemplate))
 	if err := criOTemplate.Execute(tpl, t); err != nil {
-		return fmt.Errorf("failed to execute crio template: %v", err)
+		return fmt.Errorf("failed to execute crio template: %w", err)
 	}
 
 	return nil

--- a/pkg/provisioner/templates/docker.go
+++ b/pkg/provisioner/templates/docker.go
@@ -248,7 +248,7 @@ func NewDocker(env v1alpha1.Environment) *Docker {
 func (t *Docker) Execute(tpl *bytes.Buffer, env v1alpha1.Environment) error {
 	dockerTemplate := template.Must(template.New("docker").Parse(dockerTemplate))
 	if err := dockerTemplate.Execute(tpl, t); err != nil {
-		return fmt.Errorf("failed to execute docker template: %v", err)
+		return fmt.Errorf("failed to execute docker template: %w", err)
 	}
 
 	return nil

--- a/pkg/provisioner/templates/kubernetes.go
+++ b/pkg/provisioner/templates/kubernetes.go
@@ -1642,7 +1642,7 @@ func (k *Kubernetes) Execute(tpl *bytes.Buffer, env v1alpha1.Environment) error 
 	)
 
 	if err := kubernetesTemplate.Execute(tpl, k); err != nil {
-		return fmt.Errorf("failed to execute kubernetes template: %v", err)
+		return fmt.Errorf("failed to execute kubernetes template: %w", err)
 	}
 
 	return nil
@@ -1681,14 +1681,14 @@ func NewKubeadmConfig(env v1alpha1.Environment) (*KubeadmConfig, error) {
 		if !filepath.IsAbs(kubeAdmConfigPath) {
 			cwd, err := os.Getwd()
 			if err != nil {
-				return &KubeadmConfig{}, fmt.Errorf("failed to get current working directory: %v", err)
+				return &KubeadmConfig{}, fmt.Errorf("failed to get current working directory: %w", err)
 			}
 
 			kubeAdmConfigPath = filepath.Join(cwd, strings.TrimPrefix(env.Spec.Kubernetes.KubeAdmConfig, "./"))
 		}
 		data, err := os.ReadFile(kubeAdmConfigPath) // nolint:gosec
 		if err != nil {
-			return &KubeadmConfig{}, fmt.Errorf("failed to read kubeadm config file: %v", err)
+			return &KubeadmConfig{}, fmt.Errorf("failed to read kubeadm config file: %w", err)
 		}
 
 		kConfig.Template = string(data)

--- a/pkg/provisioner/templates/nv-driver.go
+++ b/pkg/provisioner/templates/nv-driver.go
@@ -181,7 +181,7 @@ func (t *NvDriver) Execute(tpl *bytes.Buffer, env v1alpha1.Environment) error {
 	nvDriverTemplate := template.Must(template.New("nv-driver").Parse(NvDriverTemplate))
 	err := nvDriverTemplate.Execute(tpl, t)
 	if err != nil {
-		return fmt.Errorf("failed to execute nv-driver template: %v", err)
+		return fmt.Errorf("failed to execute nv-driver template: %w", err)
 	}
 	return nil
 }

--- a/pkg/utils/ip.go
+++ b/pkg/utils/ip.go
@@ -79,7 +79,7 @@ func getIPFromHTTPService(ctx context.Context, url string, timeout time.Duration
 	// Create request with context
 	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		return "", fmt.Errorf("error creating request for %s: %v", url, err)
+		return "", fmt.Errorf("error creating request for %s: %w", url, err)
 	}
 
 	// Set user agent to avoid being blocked
@@ -88,7 +88,7 @@ func getIPFromHTTPService(ctx context.Context, url string, timeout time.Duration
 	// Make the request
 	resp, err := client.Do(req)
 	if err != nil {
-		return "", fmt.Errorf("error fetching IP from %s: %v", url, err)
+		return "", fmt.Errorf("error fetching IP from %s: %w", url, err)
 	}
 	defer resp.Body.Close() // nolint:errcheck, gosec, staticcheck
 
@@ -100,7 +100,7 @@ func getIPFromHTTPService(ctx context.Context, url string, timeout time.Duration
 	// Read response body
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", fmt.Errorf("error reading response from %s: %v", url, err)
+		return "", fmt.Errorf("error reading response from %s: %w", url, err)
 	}
 
 	// Clean the IP address (remove whitespace and newlines)

--- a/pkg/utils/kubeconfig.go
+++ b/pkg/utils/kubeconfig.go
@@ -38,39 +38,39 @@ func GetKubeConfig(log *logger.FunLogger, cfg *v1alpha1.Environment, hostUrl str
 
 	session, err := p.Client.NewSession()
 	if err != nil {
-		return fmt.Errorf("error creating session: %v", err)
+		return fmt.Errorf("error creating session: %w", err)
 	}
 	defer session.Close() // nolint:errcheck, gosec
 
 	// Set up a pipe to receive the remote file content
 	remoteFile, err := session.StdoutPipe()
 	if err != nil {
-		return fmt.Errorf("error creating remote file pipe: %v", err)
+		return fmt.Errorf("error creating remote file pipe: %w", err)
 	}
 
 	// Start the remote command to read the file content
 	err = session.Start(fmt.Sprintf("/usr/bin/cat  %s", remoteFilePath))
 	if err != nil {
-		return fmt.Errorf("error starting remote command: %v", err)
+		return fmt.Errorf("error starting remote command: %w", err)
 	}
 
 	// Create a new file on the local system to save the downloaded content
 	localFile, err := os.Create(dest) // nolint:gosec
 	if err != nil {
-		return fmt.Errorf("error creating local file: %v", err)
+		return fmt.Errorf("error creating local file: %w", err)
 	}
 	defer localFile.Close() // nolint:errcheck, gosec
 
 	// Copy the remote file content to the local file
 	_, err = io.Copy(localFile, remoteFile)
 	if err != nil {
-		return fmt.Errorf("error copying remote file to local: %v", err)
+		return fmt.Errorf("error copying remote file to local: %w", err)
 	}
 
 	// Wait for the remote command to finish
 	err = session.Wait()
 	if err != nil {
-		return fmt.Errorf("error waiting for remote command: %v", err)
+		return fmt.Errorf("error waiting for remote command: %w", err)
 	}
 
 	log.Info(fmt.Sprintf("Kubeconfig saved to %s\n", dest))


### PR DESCRIPTION
## Summary

Replace all `fmt.Errorf("...: %v", err)` with `fmt.Errorf("...: %w", err)` in the `pkg/` directory for proper error chain preservation.

## Motivation

Using `%v` to format errors breaks the error chain, making it impossible for callers to use `errors.Is()` or `errors.As()` to inspect wrapped errors. This makes debugging difficult and prevents proper error handling patterns.

## Changes

**111 instances fixed across 13 files:**

| Package | File | Changes |
|---------|------|---------|
| `pkg/provider/aws` | `cluster.go` | 18 |
| `pkg/provider/aws` | `create.go` | 23 |
| `pkg/provider/aws` | `delete.go` | 17 |
| `pkg/provider/aws` | `dryrun.go` | 1 |
| `pkg/provisioner` | `provisioner.go` | 35 |
| `pkg/provisioner/templates` | `container-toolkit.go` | 1 |
| `pkg/provisioner/templates` | `containerd.go` | 1 |
| `pkg/provisioner/templates` | `crio.go` | 1 |
| `pkg/provisioner/templates` | `docker.go` | 1 |
| `pkg/provisioner/templates` | `kubernetes.go` | 3 |
| `pkg/provisioner/templates` | `nv-driver.go` | 1 |
| `pkg/utils` | `ip.go` | 3 |
| `pkg/utils` | `kubeconfig.go` | 6 |

## What Changed

```go
// Before
return fmt.Errorf("failed to create VPC: %v", err)

// After  
return fmt.Errorf("failed to create VPC: %w", err)
```

## Not Changed

- Error slices (`[]error`) - `%w` only works with single errors
- Non-`fmt.Errorf` contexts (loggers, test helpers)
- Files in `cmd/` or `vendor/` directories

## Test plan

- [x] `go build ./pkg/...` - compiles successfully
- [ ] `go test ./pkg/...` - verify no regressions