### PR TITLE
fix: Phase 0 — Critical bug fixes + provisioner resilience + E2E tests

### DIFF
--- a/api/holodeck/v1alpha1/types.go
+++ b/api/holodeck/v1alpha1/types.go
@@ -744,7 +744,6 @@ type NVIDIAContainerToolkit struct {
 	Version string `json:"version,omitempty"`
 }
 
-
 // LoadBalancer defines load balancer configuration for HA clusters
 type LoadBalancer struct {
 	// Enabled enables creation of a Network Load Balancer

--- a/pkg/provider/aws/create_test.go
+++ b/pkg/provider/aws/create_test.go
@@ -24,10 +24,11 @@ import (
 	"sync"
 	"testing"
 
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"github.com/NVIDIA/holodeck/api/holodeck/v1alpha1"
 	internalaws "github.com/NVIDIA/holodeck/internal/aws"
 	"github.com/NVIDIA/holodeck/internal/logger"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ec2"

--- a/pkg/provider/aws/status.go
+++ b/pkg/provider/aws/status.go
@@ -162,30 +162,16 @@ func update(env *v1alpha1.Environment, cachePath string) error {
 		return err
 	}
 
-	// if the cache file does not exist, check if the directory exists
-	// if the directory does not exist, create it
-	// if the directory exists, create the cache file
-	if _, err := os.Stat(cachePath); os.IsNotExist(err) {
-		dir := filepath.Dir(cachePath)
-		if _, err := os.Stat(dir); os.IsNotExist(err) {
-			err := os.MkdirAll(dir, 0750)
-			if err != nil {
-				return err
-			}
-		}
-		_, err := os.Create(cachePath) // nolint:gosec
-		if err != nil {
-			return err
-		}
-	}
-
-	// write to file
-	err = os.WriteFile(cachePath, data, 0600)
-	if err != nil {
+	// Ensure the parent directory exists
+	if err := os.MkdirAll(filepath.Dir(cachePath), 0750); err != nil {
 		return err
 	}
 
-	return nil
+	if err := os.WriteFile(cachePath, data, 0600); err != nil {
+		return err
+	}
+	// Enforce permissions even if the file already existed with broader perms
+	return os.Chmod(cachePath, 0600)
 }
 
 // updateAvailableCondition is used to mark a given resource as "available".


### PR DESCRIPTION
## Summary

Phase 0 of the [360-degree codebase evaluation](PROJECT_360_EVALUATION.md). Fixes critical bugs and hardens provisioning infrastructure.

### Critical Bug Fixes
- **storageSizeGB global mutation** — Use local variable to eliminate data race and persistent state corruption
- **log.Fatalf in goroutine** — Replace with error propagation to prevent process crash during provisioning
- **File permission race** — Remove redundant os.Create(0666) before os.WriteFile(0600) in status.go
- **Kubeconfig exposure** — Use os.OpenFile with 0600 instead of os.Create(0666)

### Provisioner Resilience
- **install_packages_with_retry** — Retry on all failures (not just NO_PUBKEY), refresh apt cache, fix broken dpkg state between retries
- **NVIDIA driver** — Update cuda-keyring to 1.1-1, add architecture detection (amd64/arm64), add 4-stage DKMS fallback chain (cuda-drivers → ubuntu-drivers → nvidia-driver-open → nvidia-headless-server)
- **Container toolkit** — Fix duplicate Execute() bug (template ran twice), add retry wrappers
- **Docker template** — Add with_retry for apt-get update calls
- **Containerd template** — Default to latest version (matching docker pattern), handle "latest" in template
- **AWS delete** — Increase instance termination waiter from 5min to 10min

### E2E Test Suite (NEW)
- Ginkgo/Gomega-based E2E tests against real AWS infrastructure (g4dn.xlarge)
- Two test entries: **containerd + kubeadm (K8s v1.35.0)** and **docker + NVIDIA runtime**
- Full lifecycle: create VPC/subnet/SG → launch EC2 → SSH provisioning → K8s validation → cleanup

## Test Plan
- [x] `go vet ./...` passes
- [x] Unit tests pass
- [x] E2E containerd+kubeadm+K8s v1.35.0: **PASS** (660s)
- [x] E2E docker+NVIDIA runtime: **PASS** (649s)
- [x] Commits signed with `-s -S` (DCO + SSH)


Made with [Cursor](https://cursor.com)