### PR TITLE
fix(utils): close SSH client in GetKubeConfig

### DIFF
--- a/pkg/utils/kubeconfig.go
+++ b/pkg/utils/kubeconfig.go
@@ -35,6 +35,7 @@ func GetKubeConfig(log *logger.FunLogger, cfg *v1alpha1.Environment, hostUrl str
 	if err != nil {
 		return err
 	}
+	defer func() { _ = p.Client.Close() }()
 
 	session, err := p.Client.NewSession()
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `defer func() { _ = p.Client.Close() }()` after `provisioner.New()` in `pkg/utils/kubeconfig.go`
- Fixes SSH connection leak: `provisioner.New()` opens an SSH connection that was never closed, leaking a TCP socket and SSH multiplexer goroutines on every call to `GetKubeConfig`

## Audit Finding
- **#4 (HIGH):** SSH client leak in `GetKubeConfig`

## Test plan
- [x] `gofmt` — no formatting issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -coverprofile=coverage.out ./pkg/...` — all PASS
- [x] `go build -o bin/holodeck cmd/cli/main.go` — compiles
- [x] `go mod tidy && go mod verify` — no changes, all modules verified