### PR TITLE
fix(aws): handle crypto/rand failure in retry jitter

### DIFF
--- a/pkg/provider/aws/retry.go
+++ b/pkg/provider/aws/retry.go
@@ -49,8 +49,11 @@ func WithRetry[T any](ctx context.Context, cfg RetryConfig, fn func() (T, error)
 
 		if attempt < cfg.MaxRetries {
 			// Add jitter
-			n, _ := rand.Int(rand.Reader, big.NewInt(int64(backoff/2)))
-			jitter := time.Duration(n.Int64())
+			n, err := rand.Int(rand.Reader, big.NewInt(int64(backoff/2)))
+			var jitter time.Duration
+			if err == nil {
+				jitter = time.Duration(n.Int64())
+			}
 			sleepDuration := backoff + jitter
 			if sleepDuration > cfg.MaxBackoff {
 				sleepDuration = cfg.MaxBackoff


### PR DESCRIPTION
## Summary
- `rand.Int` returns `(nil, error)` when the random source fails. The nil `big.Int` was dereferenced unconditionally on the next line, causing a nil pointer panic.
- Fall back to zero jitter when `rand.Int` returns an error, so retry still works with deterministic backoff.

**Audit finding:** #7 (MEDIUM)

## Changes
- `pkg/provider/aws/retry.go:52-53` — Replace `n, _ :=` with proper error handling and zero-jitter fallback

## Test plan
- [x] `gofmt` — no formatting issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -coverprofile=coverage.out ./pkg/...` — all pass
- [x] `go build -o bin/holodeck cmd/cli/main.go` — compiles
- [x] `go mod tidy && go mod verify` — all modules verified