### PR TITLE
fix(scp): log SFTP MkdirAll error instead of discarding

### DIFF
--- a/cmd/cli/scp/scp.go
+++ b/cmd/cli/scp/scp.go
@@ -218,7 +218,9 @@ func (m command) copyFileToRemote(client *sftp.Client, localPath, remotePath str
 
 	// Ensure remote directory exists (use path, not filepath, for POSIX remote paths)
 	remoteDir := path.Dir(remotePath)
-	_ = client.MkdirAll(remoteDir) // best-effort, directory may already exist
+	if err := client.MkdirAll(remoteDir); err != nil {
+		m.log.Warning("Failed to create remote directory %s (may already exist): %v", remoteDir, err)
+	}
 
 	// Create remote file
 	remoteFile, err := client.Create(remotePath)


### PR DESCRIPTION
## Summary
- Replace silent error discard (`_ = client.MkdirAll(remoteDir)`) with a warning log so permission-denied or disk-full errors are diagnosable
- The directory creation is best-effort (it may already exist), so a warning is appropriate rather than a hard error

## Audit Finding
- Finding #26 (LOW): Silently discarded error in `cmd/cli/scp/scp.go:221`

## Changes
- `cmd/cli/scp/scp.go`: Log `MkdirAll` error as warning instead of discarding with `_ =`

## Test plan
- [x] `gofmt` — no formatting issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -coverprofile=coverage.out ./pkg/...` — all tests pass
- [x] `go build -o bin/holodeck cmd/cli/main.go` — compiles
- [x] `go mod tidy && go mod verify` — all modules verified