### PR TITLE
fix(create): guard nil provider for SSH provider mode

### DIFF
--- a/cmd/cli/create/create.go
+++ b/cmd/cli/create/create.go
@@ -176,9 +176,11 @@ func (m command) run(c *cli.Context, opts *options) error {
 		opts.cache = opts.cfg
 	}
 
-	err = provider.Create()
-	if err != nil {
-		return err
+	if provider != nil {
+		err = provider.Create()
+		if err != nil {
+			return err
+		}
 	}
 
 	// Read cache after creating the environment

--- a/cmd/cli/create/create_test.go
+++ b/cmd/cli/create/create_test.go
@@ -451,3 +451,33 @@ func TestOptionsValidation(t *testing.T) {
 	assert.Equal(t, "/tmp/cache.yaml", opts.cachePath)
 	assert.Equal(t, "test-env", opts.cfg.Name)
 }
+
+func TestCreateSSHProviderDoesNotPanic(t *testing.T) {
+	log := logger.NewLogger()
+	tmpDir := t.TempDir()
+
+	opts := &options{
+		cfg: v1alpha1.Environment{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "test-ssh-env",
+			},
+			Spec: v1alpha1.EnvironmentSpec{
+				Provider: v1alpha1.ProviderSSH,
+				Instance: v1alpha1.Instance{
+					HostUrl: "192.168.1.100",
+				},
+				Auth: v1alpha1.Auth{
+					PrivateKey: "/path/to/key",
+					Username:   "root",
+				},
+			},
+		},
+		cachePath: tmpDir,
+	}
+	cmd := command{log: log}
+
+	// Should not panic — should either succeed or return an error
+	assert.NotPanics(t, func() {
+		_ = cmd.run(nil, opts)
+	})
+}


### PR DESCRIPTION
## Summary

- Guard `provider.Create()` with a nil check to prevent panic when `Spec.Provider` is `ProviderSSH`
- The SSH case in the switch statement never assigns a provider (SSH uses pre-existing infrastructure), so calling `provider.Create()` unconditionally causes a nil pointer dereference
- Add test `TestCreateSSHProviderDoesNotPanic` to verify the fix

## Audit Finding

**#1 (CRITICAL):** `cmd/cli/create/create.go:179` — nil pointer dereference when provider is SSH

## Test plan

- [x] New test `TestCreateSSHProviderDoesNotPanic` passes (was panicking before fix)
- [x] All 29 existing Ginkgo specs in `cmd/cli/create` pass
- [x] `gofmt` — no formatting issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./pkg/...` — all pass
- [x] `go build -o bin/holodeck cmd/cli/main.go` — compiles
- [x] `go mod tidy && go mod verify` — clean