### PR TITLE
fix(aws): surface NLB errors instead of swallowing them

### DIFF
--- a/pkg/provider/aws/delete.go
+++ b/pkg/provider/aws/delete.go
@@ -102,7 +102,7 @@ func (p *Provider) delete(cache *AWS) error {
 			// But we can also store it in status.Cluster properties
 			// Actually, let's check if we can get it from the environment status
 			if err := p.deleteNLBForCluster(clusterCache); err != nil {
-				p.log.Warning("Error deleting load balancer: %v", err)
+				return fmt.Errorf("failed to delete load balancer (resources may be leaked): %w", err)
 			}
 		}
 	}

--- a/pkg/provider/aws/nlb.go
+++ b/pkg/provider/aws/nlb.go
@@ -329,7 +329,9 @@ func (p *Provider) deleteTargetGroup(cache *ClusterCache) error {
 				Targets:        targets,
 			}
 			ctxDereg, cancelDereg := context.WithTimeout(context.Background(), elbv2APITimeout)
-			_, _ = p.elbv2.DeregisterTargets(ctxDereg, deregisterInput)
+			if _, err := p.elbv2.DeregisterTargets(ctxDereg, deregisterInput); err != nil {
+				p.log.Warning("Failed to deregister targets from %s: %v", cache.TargetGroupArn, err)
+			}
 			cancelDereg()
 		}
 	}


### PR DESCRIPTION
## Summary
- **DeregisterTargets** error in `pkg/provider/aws/nlb.go:332` was fully discarded (`_, _ =`). Now logs it as a warning so failures are diagnosable.
- **deleteNLBForCluster** error in `pkg/provider/aws/delete.go:104` was only warned about. Now returns the error so callers know about leaked AWS resources and can take action.

Addresses audit findings #9 (MEDIUM) and #10 (MEDIUM).

## Test plan
- [x] `gofmt` — no formatting issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./pkg/...` — all tests pass
- [x] `go build -o bin/holodeck cmd/cli/main.go` — compiles
- [x] `go mod tidy && go mod verify` — all modules verified