### PR TITLE
fix(instances): return errors from GenerateInstanceID, validate ID format

### DIFF
--- a/cmd/cli/create/create.go
+++ b/cmd/cli/create/create.go
@@ -140,8 +140,14 @@ func (m command) run(c *cli.Context, opts *options) error {
 
 	// Create instance manager and generate unique ID
 	manager := instances.NewManager(m.log, opts.cachePath)
-	instanceID := manager.GenerateInstanceID()
-	opts.cacheFile = manager.GetInstanceCacheFile(instanceID)
+	instanceID, err := manager.GenerateInstanceID()
+	if err != nil {
+		return fmt.Errorf("failed to generate instance ID: %w", err)
+	}
+	opts.cacheFile, err = manager.GetInstanceCacheFile(instanceID)
+	if err != nil {
+		return fmt.Errorf("invalid instance ID: %w", err)
+	}
 
 	// Add instance ID to environment metadata
 	if opts.cfg.Labels == nil {

--- a/internal/instances/instances_test.go
+++ b/internal/instances/instances_test.go
@@ -32,9 +32,11 @@ func TestGenerateInstanceID(t *testing.T) {
 	// Generate multiple IDs and verify they are unique
 	ids := make(map[string]bool)
 	for i := 0; i < 100; i++ {
-		id := manager.GenerateInstanceID()
+		id, err := manager.GenerateInstanceID()
+		require.NoError(t, err)
 		assert.NotEmpty(t, id)
 		assert.Len(t, id, 8) // 4 bytes = 8 hex characters
+		assert.Regexp(t, `^[0-9a-f]{8}$`, id)
 		assert.False(t, ids[id], "Generated duplicate ID: %s", id)
 		ids[id] = true
 	}
@@ -43,10 +45,51 @@ func TestGenerateInstanceID(t *testing.T) {
 func TestGetInstanceCacheFile(t *testing.T) {
 	log := logger.NewLogger()
 	manager := NewManager(log, "/tmp/holodeck-test")
-	instanceID := "test123"
 
+	// Valid 8-char hex ID
+	instanceID := "a1b2c3d4"
 	expectedPath := filepath.Join("/tmp/holodeck-test", instanceID+".yaml")
-	assert.Equal(t, expectedPath, manager.GetInstanceCacheFile(instanceID))
+	path, err := manager.GetInstanceCacheFile(instanceID)
+	require.NoError(t, err)
+	assert.Equal(t, expectedPath, path)
+
+	// Valid UUID (backward compatibility)
+	uuidID := "123e4567-e89b-12d3-a456-426614174000"
+	expectedUUIDPath := filepath.Join("/tmp/holodeck-test", uuidID+".yaml")
+	path, err = manager.GetInstanceCacheFile(uuidID)
+	require.NoError(t, err)
+	assert.Equal(t, expectedUUIDPath, path)
+}
+
+func TestGetInstanceCacheFile_RejectsTraversal(t *testing.T) {
+	log := logger.NewLogger()
+	manager := NewManager(log, t.TempDir())
+
+	_, err := manager.GetInstanceCacheFile("../../etc/passwd")
+	assert.Error(t, err, "should reject path traversal")
+}
+
+func TestGetInstanceCacheFile_RejectsInvalidFormat(t *testing.T) {
+	log := logger.NewLogger()
+	manager := NewManager(log, t.TempDir())
+
+	tests := []struct {
+		name string
+		id   string
+	}{
+		{"empty string", ""},
+		{"too short hex", "abcdef"},
+		{"shell injection", "a1b2c3d4; rm -rf /"},
+		{"uppercase hex", "A1B2C3D4"},
+		{"non-hex characters", "test1234"},
+		{"path separator", "a1b2/c3d4"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := manager.GetInstanceCacheFile(tt.id)
+			assert.Error(t, err, "should reject ID: %q", tt.id)
+		})
+	}
 }
 
 func TestListInstances(t *testing.T) {
@@ -62,9 +105,10 @@ func TestListInstances(t *testing.T) {
 	log := logger.NewLogger()
 	manager := NewManager(log, tempDir)
 
-	// Create a test instance file
-	instanceID := "test123"
-	cacheFile := manager.GetInstanceCacheFile(instanceID)
+	// Create a test instance file with valid 8-char hex ID
+	instanceID := "a1b2c3d4"
+	cacheFile, err := manager.GetInstanceCacheFile(instanceID)
+	require.NoError(t, err)
 	err = os.MkdirAll(filepath.Dir(cacheFile), 0750)
 	require.NoError(t, err)
 	err = os.WriteFile(cacheFile, []byte(`apiVersion: holodeck.nvidia.com/v1alpha1
@@ -72,7 +116,7 @@ kind: Environment
 metadata:
   name: test-instance
   labels:
-    holodeck-instance-id: test123
+    holodeck-instance-id: a1b2c3d4
 spec:
   provider: aws
 `), 0600)
@@ -100,9 +144,10 @@ func TestGetInstance(t *testing.T) {
 	log := logger.NewLogger()
 	manager := NewManager(log, tempDir)
 
-	// Create a test instance file
-	instanceID := "test123"
-	cacheFile := manager.GetInstanceCacheFile(instanceID)
+	// Create a test instance file with valid hex ID
+	instanceID := "a1b2c3d4"
+	cacheFile, err := manager.GetInstanceCacheFile(instanceID)
+	require.NoError(t, err)
 	err = os.MkdirAll(filepath.Dir(cacheFile), 0750)
 	require.NoError(t, err)
 	err = os.WriteFile(cacheFile, []byte(`apiVersion: holodeck.nvidia.com/v1alpha1
@@ -110,7 +155,7 @@ kind: Environment
 metadata:
   name: test-instance
   labels:
-    holodeck-instance-id: test123
+    holodeck-instance-id: a1b2c3d4
 spec:
   provider: aws
 `), 0600)
@@ -123,7 +168,7 @@ spec:
 	assert.Equal(t, "test-instance", instance.Name)
 	assert.Equal(t, v1alpha1.ProviderAWS, instance.Provider)
 
-	// Test getting non-existent instance
+	// Test getting instance with invalid ID format
 	_, err = manager.GetInstance("nonexistent")
 	assert.Error(t, err)
 }
@@ -141,9 +186,10 @@ func TestDeleteInstance(t *testing.T) {
 	log := logger.NewLogger()
 	manager := NewManager(log, tempDir)
 
-	// Create a test instance file
-	instanceID := "test123"
-	cacheFile := manager.GetInstanceCacheFile(instanceID)
+	// Create a test instance file with valid hex ID
+	instanceID := "a1b2c3d4"
+	cacheFile, err := manager.GetInstanceCacheFile(instanceID)
+	require.NoError(t, err)
 	err = os.MkdirAll(filepath.Dir(cacheFile), 0750)
 	require.NoError(t, err)
 	err = os.WriteFile(cacheFile, []byte(`apiVersion: holodeck.nvidia.com/v1alpha1
@@ -151,7 +197,7 @@ kind: Environment
 metadata:
   name: test-instance
   labels:
-    holodeck-instance-id: test123
+    holodeck-instance-id: a1b2c3d4
 spec:
   provider: aws
 `), 0600)
@@ -165,7 +211,7 @@ spec:
 	_, err = os.Stat(cacheFile)
 	assert.True(t, os.IsNotExist(err))
 
-	// Test deleting non-existent instance
+	// Test deleting instance with invalid ID format
 	err = manager.DeleteInstance("nonexistent")
 	assert.Error(t, err)
 }
@@ -183,9 +229,10 @@ func TestGetInstanceByFilename(t *testing.T) {
 	log := logger.NewLogger()
 	manager := NewManager(log, tempDir)
 
-	// Create a test instance file with UUID filename
+	// Create a test instance file with UUID filename (backward compatibility)
 	instanceID := "123e4567-e89b-12d3-a456-426614174000"
-	cacheFile := manager.GetInstanceCacheFile(instanceID)
+	cacheFile, err := manager.GetInstanceCacheFile(instanceID)
+	require.NoError(t, err)
 	err = os.MkdirAll(filepath.Dir(cacheFile), 0750)
 	require.NoError(t, err)
 	err = os.WriteFile(cacheFile, []byte(`apiVersion: holodeck.nvidia.com/v1alpha1


### PR DESCRIPTION
## Summary
- Change `GenerateInstanceID` to return `(string, error)` instead of silently returning empty string on `crypto/rand` failure (which produced a cache file named `.yaml`)
- Add hex format validation to `GetInstanceCacheFile` to prevent path traversal attacks (rejects `../../etc/passwd`, shell metacharacters, etc.)
- Accept both 8-char hex IDs (new format) and UUID format (backward compatibility)
- Update all callers in `cmd/cli/create/create.go` and internal methods (`GetInstance`, `DeleteInstance`, `GetInstanceByFilename`)

**Audit findings:** #8 (MEDIUM), #35 (LOW)

## Test plan
- [x] `TestGenerateInstanceID` — verifies 8-char hex output and error return
- [x] `TestGetInstanceCacheFile` — verifies valid hex and UUID IDs accepted
- [x] `TestGetInstanceCacheFile_RejectsTraversal` — verifies `../../etc/passwd` rejected
- [x] `TestGetInstanceCacheFile_RejectsInvalidFormat` — verifies empty, short, uppercase, non-hex, shell injection, path separators all rejected
- [x] All existing tests updated and passing
- [x] `gofmt` clean
- [x] `golangci-lint` — 0 issues
- [x] `go test ./internal/instances/... ./cmd/cli/create/... -v` — PASS
- [x] `go build -o bin/holodeck cmd/cli/main.go` — compiles
- [x] `go mod tidy && go mod verify` — clean