### PR TITLE
perf: pre-compile templates, hoist regex, filter DescribeLoadBalancers

### DIFF
--- a/pkg/gitref/resolver.go
+++ b/pkg/gitref/resolver.go
@@ -132,14 +132,15 @@ func (r *GitHubResolver) Resolve(
 	return fullSHA, shortSHA, nil
 }
 
+var repoURLPattern = regexp.MustCompile(`github\.com[:/]([^/]+)/([^/.]+)`)
+
 // ParseRepoURL extracts owner and repo name from a GitHub URL.
 // Handles:
 //   - https://github.com/NVIDIA/nvidia-container-toolkit.git
 //   - git@github.com:NVIDIA/nvidia-container-toolkit.git
 //   - github.com/NVIDIA/nvidia-container-toolkit
 func ParseRepoURL(repo string) (owner, name string, err error) {
-	re := regexp.MustCompile(`github\.com[:/]([^/]+)/([^/.]+)`)
-	matches := re.FindStringSubmatch(repo)
+	matches := repoURLPattern.FindStringSubmatch(repo)
 	if len(matches) != 3 {
 		return "", "", fmt.Errorf("invalid GitHub repo URL: %s", repo)
 	}

--- a/pkg/provider/aws/delete.go
+++ b/pkg/provider/aws/delete.go
@@ -64,7 +64,10 @@ func (p *Provider) deleteNLBForCluster(cache *ClusterCache) error {
 	ctx, cancel := context.WithTimeout(context.Background(), elbv2APITimeout)
 	defer cancel()
 
-	describeInput := &elasticloadbalancingv2.DescribeLoadBalancersInput{}
+	lbName := fmt.Sprintf("%s-nlb", p.ObjectMeta.Name)
+	describeInput := &elasticloadbalancingv2.DescribeLoadBalancersInput{
+		Names: []string{lbName},
+	}
 	describeOutput, err := p.elbv2.DescribeLoadBalancers(ctx, describeInput)
 	if err != nil {
 		return fmt.Errorf("error describing load balancers: %w", err)

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -44,6 +44,11 @@ set -xe
 
 const remoteKindConfig = "/etc/kubernetes/kind.yaml"
 
+var (
+	shebangTmpl     = template.Must(template.New("shebang").Parse(Shebang))
+	commonFuncsTmpl = template.Must(template.New("common-functions").Parse(templates.CommonFunctions))
+)
+
 const (
 	// sshMaxRetries is the number of SSH connection attempts before giving up.
 	sshMaxRetries = 20
@@ -431,14 +436,10 @@ func (p *Provisioner) copyFileToRemoteSFTP(localPath, remotePath string) error {
 }
 
 func addScriptHeader(tpl *bytes.Buffer) error {
-	// Add shebang to the script
-	shebang := template.Must(template.New("shebang").Parse(Shebang))
-	if err := shebang.Execute(tpl, nil); err != nil {
+	if err := shebangTmpl.Execute(tpl, nil); err != nil {
 		return fmt.Errorf("failed to add shebang to the script: %w", err)
 	}
-	// Add common functions to the script
-	commonFunctions := template.Must(template.New("common-functions").Parse(templates.CommonFunctions))
-	if err := commonFunctions.Execute(tpl, nil); err != nil {
+	if err := commonFuncsTmpl.Execute(tpl, nil); err != nil {
 		return fmt.Errorf("failed to add common functions to the script: %w", err)
 	}
 	return nil

--- a/pkg/provisioner/templates/container-toolkit.go
+++ b/pkg/provisioner/templates/container-toolkit.go
@@ -522,6 +522,12 @@ holodeck_mark_installed "$COMPONENT" "${SHORT_COMMIT}"
 holodeck_log "INFO" "$COMPONENT" "Successfully installed from ${TRACK_BRANCH}: ${SHORT_COMMIT}"
 `
 
+var (
+	ctkPackageTmpl = template.Must(template.New("ctk-package").Parse(containerToolkitPackageTemplate))
+	ctkGitTmpl     = template.Must(template.New("ctk-git").Parse(containerToolkitGitTemplate))
+	ctkLatestTmpl  = template.Must(template.New("ctk-latest").Parse(containerToolkitLatestTemplate))
+)
+
 // ContainerToolkit holds configuration for NVIDIA Container Toolkit installation.
 type ContainerToolkit struct {
 	ContainerRuntime string
@@ -603,20 +609,19 @@ func (t *ContainerToolkit) SetResolvedCommit(shortSHA string) {
 
 // Execute renders the appropriate template based on source.
 func (t *ContainerToolkit) Execute(tpl *bytes.Buffer, env v1alpha1.Environment) error {
-	var templateContent string
+	var tmpl *template.Template
 
 	switch t.Source {
 	case "package", "":
-		templateContent = containerToolkitPackageTemplate
+		tmpl = ctkPackageTmpl
 	case "git":
-		templateContent = containerToolkitGitTemplate
+		tmpl = ctkGitTmpl
 	case "latest":
-		templateContent = containerToolkitLatestTemplate
+		tmpl = ctkLatestTmpl
 	default:
 		return fmt.Errorf("unknown CTK source: %s", t.Source)
 	}
 
-	tmpl := template.Must(template.New("container-toolkit").Parse(templateContent))
 	if err := tmpl.Execute(tpl, t); err != nil {
 		return fmt.Errorf("failed to execute container-toolkit template: %w", err)
 	}

--- a/pkg/provisioner/templates/kubeadm_cluster.go
+++ b/pkg/provisioner/templates/kubeadm_cluster.go
@@ -286,6 +286,12 @@ holodeck_mark_installed "$COMPONENT" "joined"
 holodeck_log "INFO" "$COMPONENT" "Node joined successfully"
 `
 
+var (
+	kubeadmInitTmpl   = template.Must(template.New("kubeadm-init").Parse(KubeadmInitTemplate))
+	kubeadmJoinTmpl   = template.Must(template.New("kubeadm-join").Parse(KubeadmJoinTemplate))
+	kubeadmPrereqTmpl = template.Must(template.New("kubeadm-prereq").Parse(strings.TrimSpace(KubeadmPrereqTemplate)))
+)
+
 // KubeadmInitConfig holds configuration for kubeadm init
 type KubeadmInitConfig struct {
 	Environment          *v1alpha1.Environment
@@ -310,8 +316,7 @@ func (c *KubeadmInitConfig) Execute(tpl *bytes.Buffer) error {
 		IsHA:                 fmt.Sprintf("%t", c.IsHA),
 	}
 
-	tmpl := template.Must(template.New("kubeadm-init").Parse(KubeadmInitTemplate))
-	if err := tmpl.Execute(tpl, data); err != nil {
+	if err := kubeadmInitTmpl.Execute(tpl, data); err != nil {
 		return fmt.Errorf("failed to execute kubeadm init template: %w", err)
 	}
 	return nil
@@ -342,8 +347,7 @@ func (c *KubeadmJoinConfig) Execute(tpl *bytes.Buffer) error {
 		IsControlPlane:       fmt.Sprintf("%t", c.IsControlPlane),
 	}
 
-	tmpl := template.Must(template.New("kubeadm-join").Parse(KubeadmJoinTemplate))
-	if err := tmpl.Execute(tpl, data); err != nil {
+	if err := kubeadmJoinTmpl.Execute(tpl, data); err != nil {
 		return fmt.Errorf("failed to execute kubeadm join template: %w", err)
 	}
 	return nil
@@ -434,8 +438,7 @@ func (c *KubeadmPrereqConfig) Execute(tpl *bytes.Buffer) error {
 		return fmt.Errorf("failed to create kubernetes config: %w", err)
 	}
 
-	tmpl := template.Must(template.New("kubeadm-prereq").Parse(strings.TrimSpace(KubeadmPrereqTemplate)))
-	if err := tmpl.Execute(tpl, k); err != nil {
+	if err := kubeadmPrereqTmpl.Execute(tpl, k); err != nil {
 		return fmt.Errorf("failed to execute kubeadm prereq template: %w", err)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- Move template parsing from per-call to package-level vars (eliminates 75+ recompiles per cluster)
- Hoist `regexp.MustCompile` from function body to package-level var in resolver.go
- Filter `DescribeLoadBalancers` by name instead of listing all LBs in the account

## Audit Findings
- **#22 (MEDIUM)**: Template recompilation in provisioner Execute methods
- **#23 (MEDIUM)**: Regex compiled inside function in resolver.go
- **#24 (MEDIUM)**: Unfiltered DescribeLoadBalancers in delete.go

## Changes
- `pkg/provisioner/provisioner.go`: Package-level template vars for addScriptHeader
- `pkg/provisioner/templates/*.go`: Package-level template vars for Execute methods
- `pkg/gitref/resolver.go`: Package-level regex var
- `pkg/provider/aws/delete.go`: Filter DescribeLoadBalancers by name

## Test plan
- [x] `gofmt` — no formatting issues
- [x] `go build` — compiles
- [x] `go test ./pkg/...` — all tests pass