### PR TITLE
fix(cluster): guard substring slice + redact join credentials in logs

### DIFF
--- a/pkg/provisioner/cluster.go
+++ b/pkg/provisioner/cluster.go
@@ -344,9 +344,13 @@ func (cp *ClusterProvisioner) extractJoinInfo(provisioner *Provisioner) error {
 		cp.CertificateKey = strings.TrimSpace(string(certKeyOut))
 	}
 
-	cp.log.Info("Join credentials ready - Token: %s, CA Hash: %s", cp.JoinToken, cp.CACertHash[:32]+"...")
+	hashPreview := cp.CACertHash
+	if len(hashPreview) > 32 {
+		hashPreview = hashPreview[:32] + "..."
+	}
+	cp.log.Info("Join credentials ready - Token: [REDACTED], CA Hash: %s", hashPreview)
 	if cp.CertificateKey != "" {
-		cp.log.Info("Certificate key for control-plane joins: %s...", cp.CertificateKey[:16])
+		cp.log.Info("Certificate key for control-plane joins: [REDACTED]")
 	}
 
 	return nil


### PR DESCRIPTION
## Summary
- Add length guard before `CACertHash[:32]` to prevent panic on truncated openssl output
- Redact bootstrap token and certificate key from log output

## Audit Findings
- **#3 (HIGH)**: Substring panic on short CACertHash
- **#19 (MEDIUM)**: Credentials logged in plain text

## Changes
- `pkg/provisioner/cluster.go`: Length guard + log redaction for join credentials

## Test plan
- [x] `gofmt` — no formatting issues
- [x] `go build` — compiles
- [x] `go test ./pkg/...` — all tests pass