### PR TITLE
fix(ssh): remove unreachable code in connectOrDie, wrap last error

### DIFF
--- a/cmd/cli/dryrun/dryrun.go
+++ b/cmd/cli/dryrun/dryrun.go
@@ -147,22 +147,16 @@ func connectOrDie(keyPath, userName, hostUrl string) error {
 		HostKeyCallback: sshutil.TOFUHostKeyCallback(),
 	}
 
-	connectionFailed := false
+	var lastErr error
 	for range 20 {
 		client, err := ssh.Dial("tcp", hostUrl+":22", sshConfig)
 		if err == nil {
-			client.Close() // nolint:errcheck, gosec
-			return nil     // Connection succeeded,
+			_ = client.Close()
+			return nil
 		}
-		connectionFailed = true
-		// Sleep for a brief moment before retrying.
-		// You can adjust the duration based on your requirements.
+		lastErr = err
 		time.Sleep(1 * time.Second)
 	}
 
-	if connectionFailed {
-		return fmt.Errorf("failed to connect to %s", hostUrl)
-	}
-
-	return nil
+	return fmt.Errorf("failed to connect to %s after 20 retries: %w", hostUrl, lastErr)
 }

--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -452,20 +452,13 @@ func connectOrDie(keyPath, userName, hostUrl string) (*ssh.Client, error) {
 		HostKeyCallback: sshutil.TOFUHostKeyCallback(),
 	}
 
-	connectionFailed := false
 	for range sshMaxRetries {
 		client, err = ssh.Dial("tcp", hostUrl+":22", sshConfig)
 		if err == nil {
-			return client, nil // Connection succeeded, return the client.
+			return client, nil
 		}
-		connectionFailed = true
-		// Brief delay before retrying.
 		time.Sleep(sshRetryDelay)
 	}
 
-	if connectionFailed {
-		return nil, fmt.Errorf("failed to connect to %s after %d retries, giving up", hostUrl, sshMaxRetries)
-	}
-
-	return client, nil
+	return nil, fmt.Errorf("failed to connect to %s after %d retries: %w", hostUrl, sshMaxRetries, err)
 }


### PR DESCRIPTION
## Summary
- Remove dead code after retry loops in both provisioner and dryrun connectOrDie
- Wrap last dial error with `%w` so callers can inspect the root cause

## Audit Findings
- **#5 (HIGH)**: Dead code in provisioner connectOrDie
- **#6 (HIGH)**: Dead code in dryrun connectOrDie
- **#27 (LOW)**: Error not wrapped with %w

## Changes
- `pkg/provisioner/provisioner.go`: Simplify connectOrDie retry loop
- `cmd/cli/dryrun/dryrun.go`: Simplify connectOrDie retry loop + wrap error

## Test plan
- [x] `gofmt` — no formatting issues
- [x] `go build` — compiles
- [x] `go test ./pkg/...` — all tests pass