### PR TITLE
fix(provisioner): close SSH client before reassign, close pipe reader

### DIFF
--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -216,6 +216,12 @@ func (p *Provisioner) resetConnection() error {
 func (p *Provisioner) provision() error {
 	var err error
 
+	// Close existing client before creating new connection
+	if p.Client != nil {
+		_ = p.Client.Close()
+		p.Client = nil
+	}
+
 	// Create a new ssh connection
 	p.Client, err = connectOrDie(p.KeyPath, p.UserName, p.HostUrl)
 	if err != nil {
@@ -259,6 +265,7 @@ func (p *Provisioner) provision() error {
 
 	_ = writer.Close()
 	wg.Wait()
+	_ = reader.Close()
 
 	select {
 	case copyErr := <-copyErrCh:


### PR DESCRIPTION
## Summary
- Close existing SSH client before overwriting with new connection in `provision()`
- Close io.Pipe reader after WaitGroup completes to prevent goroutine leak

## Audit Findings
- **#14 (MEDIUM)**: SSH client overwritten without closing in provision()
- **#29 (LOW)**: io.Pipe reader never closed

## Changes
- `pkg/provisioner/provisioner.go`: Add client close guard + pipe reader close

## Test plan
- [x] `gofmt` — no formatting issues
- [x] `go build` — compiles
- [x] `go test ./pkg/...` — all tests pass