### PR TITLE
perf(cluster): parallelize node provisioning, join info, source/dest check

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/stretchr/testify v1.11.1
 	github.com/urfave/cli/v2 v2.27.7
 	golang.org/x/crypto v0.48.0
+	golang.org/x/sync v0.19.0
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/apimachinery v0.35.1
 	sigs.k8s.io/controller-runtime v0.23.1
@@ -54,7 +55,6 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/mod v0.32.0 // indirect
 	golang.org/x/net v0.49.0 // indirect
-	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.41.0 // indirect
 	golang.org/x/text v0.34.0 // indirect
 	golang.org/x/tools v0.41.0 // indirect


### PR DESCRIPTION
## Summary
- Parallelize `provisionBaseOnAllNodes` with errgroup (N nodes concurrently instead of sequential)
- Combine 3 SSH sessions into 1 script in `extractJoinInfo`
- Parallelize `disableSourceDestCheck` API calls with errgroup

## Audit Findings
- **#20 (MEDIUM)**: Sequential node provisioning in provisionBaseOnAllNodes
- **#21 (MEDIUM)**: Multiple SSH sessions in extractJoinInfo
- **#25 (MEDIUM)**: Sequential disableSourceDestCheck API calls

## Changes
- `pkg/provisioner/cluster.go`: Parallel provisionBaseOnAllNodes + combined extractJoinInfo
- `pkg/provider/aws/cluster.go`: Parallel disableSourceDestCheck

## Test plan
- [x] `gofmt` — no formatting issues
- [x] `go build` — compiles
- [x] `go test ./pkg/...` — all tests pass