### PR TITLE
fix(aws): propagate architecture in cluster mode

### DIFF
--- a/api/holodeck/v1alpha1/types.go
+++ b/api/holodeck/v1alpha1/types.go
@@ -185,10 +185,10 @@ type ControlPlaneSpec struct {
 	Count int32 `json:"count"`
 
 	// InstanceType specifies the EC2 instance type for control-plane nodes.
+	// Default is "m5.xlarge" (x86_64). For arm64, use Graviton types
+	// (e.g., "m7g.xlarge", "c7g.xlarge").
 	// +kubebuilder:default="m5.xlarge"
 	// +optional
-	// +optional
-
 	InstanceType string `json:"instanceType,omitempty"`
 
 	// OS specifies the operating system by ID (e.g., "ubuntu-22.04").
@@ -236,10 +236,10 @@ type WorkerPoolSpec struct {
 
 	// InstanceType specifies the EC2 instance type for worker nodes.
 	// For GPU workloads, use GPU instance types (g4dn, p4d, etc.).
+	// Default is "g4dn.xlarge" (x86_64). For arm64 GPU workloads,
+	// use "g5g.xlarge" or similar Graviton GPU instances.
 	// +kubebuilder:default="g4dn.xlarge"
 	// +optional
-	// +optional
-
 	InstanceType string `json:"instanceType,omitempty"`
 
 	// OS specifies the operating system by ID (e.g., "ubuntu-22.04").

--- a/pkg/provider/aws/cluster.go
+++ b/pkg/provider/aws/cluster.go
@@ -396,7 +396,12 @@ func (p *Provider) createInstances(
 	image *v1alpha1.Image,
 ) ([]InstanceInfo, error) {
 	// Resolve AMI for this node pool
-	resolved, err := p.resolveImageForNode(os, image, "")
+	// Determine architecture from image spec
+	var arch string
+	if image != nil && image.Architecture != "" {
+		arch = image.Architecture
+	}
+	resolved, err := p.resolveImageForNode(os, image, arch)
 	if err != nil {
 		return nil, fmt.Errorf("error resolving AMI: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Pass Image.Architecture to resolveImageForNode in cluster mode (was always empty string, defaulting to x86_64)
- Add documentation for arm64 instance type alternatives in API types

## Test plan
- [ ] go test ./pkg/provider/aws/... passes
- [ ] golangci-lint run ./... passes
- [ ] make check-modules passes