### PR TITLE
fix(templates): dynamic CUDA repo arch for arm64 support

### DIFF
--- a/pkg/provisioner/templates/nv-driver.go
+++ b/pkg/provisioner/templates/nv-driver.go
@@ -115,8 +115,13 @@ holodeck_progress "$COMPONENT" 3 5 "Adding CUDA repository"
 if [[ ! -f /etc/apt/sources.list.d/cuda*.list ]] || \
    [[ ! -f /usr/share/keyrings/cuda-archive-keyring.gpg ]]; then
     distribution=$(. /etc/os-release; echo "${ID}${VERSION_ID}" | sed -e 's/\.//g')
+    # Determine CUDA repo architecture (NVIDIA uses "sbsa" for arm64 servers)
+    CUDA_ARCH="$(uname -m)"
+    if [[ "$CUDA_ARCH" == "aarch64" ]]; then
+        CUDA_ARCH="sbsa"
+    fi
     holodeck_retry 3 "$COMPONENT" wget -q \
-        "https://developer.download.nvidia.com/compute/cuda/repos/$distribution/x86_64/cuda-keyring_1.1-1_all.deb"
+        "https://developer.download.nvidia.com/compute/cuda/repos/$distribution/${CUDA_ARCH}/cuda-keyring_1.1-1_all.deb"
     sudo dpkg -i cuda-keyring_1.1-1_all.deb
     rm -f cuda-keyring_1.1-1_all.deb
     holodeck_retry 3 "$COMPONENT" sudo apt-get update

--- a/pkg/provisioner/templates/nv-driver_test.go
+++ b/pkg/provisioner/templates/nv-driver_test.go
@@ -318,3 +318,33 @@ func TestNvDriver_Execute_UnknownSource(t *testing.T) {
 	assert.Error(t, err)
 	assert.Contains(t, err.Error(), "unknown driver source")
 }
+
+func TestNVDriverTemplate_CUDARepoArch(t *testing.T) {
+	driver := &NvDriver{
+		Branch: defaultNVBranch,
+	}
+
+	var output bytes.Buffer
+	err := driver.Execute(&output, v1alpha1.Environment{})
+	require.NoError(t, err)
+
+	outStr := output.String()
+
+	// Must NOT contain hardcoded x86_64 in the CUDA repo URL
+	require.NotContains(t, outStr, "cuda/repos/$distribution/x86_64/",
+		"Template must not hardcode x86_64 in the CUDA repository URL")
+
+	// Must contain runtime architecture detection
+	require.Contains(t, outStr, `CUDA_ARCH="$(uname -m)"`,
+		"Template must detect architecture at runtime via uname -m")
+
+	// Must contain aarch64 -> sbsa mapping
+	require.Contains(t, outStr, `if [[ "$CUDA_ARCH" == "aarch64" ]]; then`,
+		"Template must check for aarch64 architecture")
+	require.Contains(t, outStr, `CUDA_ARCH="sbsa"`,
+		"Template must map aarch64 to sbsa for NVIDIA CUDA repos")
+
+	// Must use CUDA_ARCH variable in the wget URL
+	require.Contains(t, outStr, "${CUDA_ARCH}/cuda-keyring",
+		"Template must use CUDA_ARCH variable in the wget URL")
+}


### PR DESCRIPTION
## Summary
- Replace hardcoded `x86_64` in CUDA repository URL with runtime `uname -m` detection
- Map `aarch64` to `sbsa` (NVIDIA's arm64 server CUDA repo convention)
- Add dedicated test verifying no hardcoded x86_64 and proper arch mapping

## Test plan
- [x] Unit test verifies template uses runtime arch detection (`TestNVDriverTemplate_CUDARepoArch`)
- [x] `go test ./pkg/provisioner/templates/...` passes
- [x] `golangci-lint run ./...` passes (0 issues)
- [ ] CI passes