### PR TITLE
feat(aws): AMI architecture detection and cross-validation

### DIFF
--- a/pkg/provider/aws/aws_ginkgo_test.go
+++ b/pkg/provider/aws/aws_ginkgo_test.go
@@ -340,7 +340,12 @@ status:
 				optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
 				return &ec2.DescribeInstanceTypesOutput{
 					InstanceTypes: []types.InstanceTypeInfo{
-						{InstanceType: types.InstanceTypeT3Medium},
+						{InstanceType: types.InstanceTypeT3Medium,
+							ProcessorInfo: &types.ProcessorInfo{
+								SupportedArchitectures: []types.ArchitectureType{
+									types.ArchitectureTypeX8664,
+								},
+							}},
 					},
 				}, nil
 			}
@@ -355,8 +360,18 @@ status:
 				optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
 				return &ec2.DescribeInstanceTypesOutput{
 					InstanceTypes: []types.InstanceTypeInfo{
-						{InstanceType: types.InstanceTypeT3Large},
-						{InstanceType: types.InstanceTypeT3Xlarge},
+						{InstanceType: types.InstanceTypeT3Large,
+							ProcessorInfo: &types.ProcessorInfo{
+								SupportedArchitectures: []types.ArchitectureType{
+									types.ArchitectureTypeX8664,
+								},
+							}},
+						{InstanceType: types.InstanceTypeT3Xlarge,
+							ProcessorInfo: &types.ProcessorInfo{
+								SupportedArchitectures: []types.ArchitectureType{
+									types.ArchitectureTypeX8664,
+								},
+							}},
 					},
 				}, nil
 			}
@@ -518,7 +533,12 @@ status:
 				optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
 				return &ec2.DescribeInstanceTypesOutput{
 					InstanceTypes: []types.InstanceTypeInfo{
-						{InstanceType: types.InstanceTypeT3Medium},
+						{InstanceType: types.InstanceTypeT3Medium,
+							ProcessorInfo: &types.ProcessorInfo{
+								SupportedArchitectures: []types.ArchitectureType{
+									types.ArchitectureTypeX8664,
+								},
+							}},
 					},
 				}, nil
 			}
@@ -563,7 +583,12 @@ status:
 				optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
 				return &ec2.DescribeInstanceTypesOutput{
 					InstanceTypes: []types.InstanceTypeInfo{
-						{InstanceType: types.InstanceTypeT3Medium},
+						{InstanceType: types.InstanceTypeT3Medium,
+							ProcessorInfo: &types.ProcessorInfo{
+								SupportedArchitectures: []types.ArchitectureType{
+									types.ArchitectureTypeX8664,
+								},
+							}},
 					},
 				}, nil
 			}

--- a/pkg/provider/aws/aws_test.go
+++ b/pkg/provider/aws/aws_test.go
@@ -1226,7 +1226,12 @@ spec:
 				optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
 				return &ec2.DescribeInstanceTypesOutput{
 					InstanceTypes: []types.InstanceTypeInfo{
-						{InstanceType: types.InstanceTypeT3Medium},
+						{InstanceType: types.InstanceTypeT3Medium,
+							ProcessorInfo: &types.ProcessorInfo{
+								SupportedArchitectures: []types.ArchitectureType{
+									types.ArchitectureTypeX8664,
+								},
+							}},
 					},
 				}, nil
 			}
@@ -1471,7 +1476,12 @@ status:
 					optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
 					return &ec2.DescribeInstanceTypesOutput{
 						InstanceTypes: []types.InstanceTypeInfo{
-							{InstanceType: types.InstanceTypeT3Medium},
+							{InstanceType: types.InstanceTypeT3Medium,
+								ProcessorInfo: &types.ProcessorInfo{
+									SupportedArchitectures: []types.ArchitectureType{
+										types.ArchitectureTypeX8664,
+									},
+								}},
 						},
 					}, nil
 				}
@@ -1519,7 +1529,12 @@ status:
 					optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
 					return &ec2.DescribeInstanceTypesOutput{
 						InstanceTypes: []types.InstanceTypeInfo{
-							{InstanceType: types.InstanceTypeT4gMedium},
+							{InstanceType: types.InstanceTypeT4gMedium,
+								ProcessorInfo: &types.ProcessorInfo{
+									SupportedArchitectures: []types.ArchitectureType{
+										types.ArchitectureTypeArm64,
+									},
+								}},
 						},
 					}, nil
 				}
@@ -1598,7 +1613,12 @@ status:
 					optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
 					return &ec2.DescribeInstanceTypesOutput{
 						InstanceTypes: []types.InstanceTypeInfo{
-							{InstanceType: types.InstanceTypeT3Medium},
+							{InstanceType: types.InstanceTypeT3Medium,
+								ProcessorInfo: &types.ProcessorInfo{
+									SupportedArchitectures: []types.ArchitectureType{
+										types.ArchitectureTypeX8664,
+									},
+								}},
 						},
 					}, nil
 				}
@@ -1699,7 +1719,12 @@ status:
 					optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
 					return &ec2.DescribeInstanceTypesOutput{
 						InstanceTypes: []types.InstanceTypeInfo{
-							{InstanceType: types.InstanceTypeT3Medium},
+							{InstanceType: types.InstanceTypeT3Medium,
+								ProcessorInfo: &types.ProcessorInfo{
+									SupportedArchitectures: []types.ArchitectureType{
+										types.ArchitectureTypeX8664,
+									},
+								}},
 						},
 					}, nil
 				}

--- a/pkg/provider/aws/mock_ec2_test.go
+++ b/pkg/provider/aws/mock_ec2_test.go
@@ -298,8 +298,22 @@ func (m *MockEC2Client) DescribeInstanceTypes(ctx context.Context, params *ec2.D
 	}
 	return &ec2.DescribeInstanceTypesOutput{
 		InstanceTypes: []types.InstanceTypeInfo{
-			{InstanceType: types.InstanceTypeT3Medium},
-			{InstanceType: types.InstanceTypeT3Large},
+			{
+				InstanceType: types.InstanceTypeT3Medium,
+				ProcessorInfo: &types.ProcessorInfo{
+					SupportedArchitectures: []types.ArchitectureType{
+						types.ArchitectureTypeX8664,
+					},
+				},
+			},
+			{
+				InstanceType: types.InstanceTypeT3Large,
+				ProcessorInfo: &types.ProcessorInfo{
+					SupportedArchitectures: []types.ArchitectureType{
+						types.ArchitectureTypeX8664,
+					},
+				},
+			},
 		},
 	}, nil
 }


### PR DESCRIPTION
## Summary
- Add `describeImageArch` helper to query AMI architecture from EC2
- Update `ResolvedImage` to include `Architecture` field
- Update `resolveImageForNode` to return architecture for explicit ImageId (was skipping all arch detection)
- Add `getInstanceTypeArch` to query instance type supported architectures via `ProcessorInfo`
- Cross-validate AMI arch against instance type arch in `DryRun()`
- Update `resolveOSToAMI` to store resolved architecture

Catches arm64 AMI + x86_64 instance type mismatches with a clear error message instead of cryptic boot failures.

## Test plan
- [x] Unit tests for `describeImageArch` with mock EC2 client
- [x] Unit test for `resolveImageForNode` returning architecture for explicit ImageId
- [x] Unit test for `DryRun()` detecting architecture mismatch
- [x] Unit test for `DryRun()` succeeding when architectures match
- [x] `go test ./pkg/provider/aws/...` passes (84/84)
- [x] `golangci-lint run ./...` passes (0 issues)
- [ ] CI passes