### PR TITLE
fix(templates): dynamic CUDA repo arch for arm64 support

### DIFF
--- a/pkg/provisioner/templates/nv-driver.go
+++ b/pkg/provisioner/templates/nv-driver.go
@@ -113,8 +113,13 @@ holodeck_progress "$COMPONENT" 3 5 "Adding CUDA repository"
 if [[ ! -f /etc/apt/sources.list.d/cuda*.list ]] || \
    [[ ! -f /usr/share/keyrings/cuda-archive-keyring.gpg ]]; then
     distribution=$(. /etc/os-release; echo "${ID}${VERSION_ID}" | sed -e 's/\.//g')
+    # Determine CUDA repo architecture (NVIDIA uses "sbsa" for arm64 servers)
+    CUDA_ARCH="$(uname -m)"
+    if [[ "$CUDA_ARCH" == "aarch64" ]]; then
+        CUDA_ARCH="sbsa"
+    fi
     holodeck_retry 3 "$COMPONENT" wget -q \
-        "https://developer.download.nvidia.com/compute/cuda/repos/$distribution/x86_64/cuda-keyring_1.1-1_all.deb"
+        "https://developer.download.nvidia.com/compute/cuda/repos/$distribution/${CUDA_ARCH}/cuda-keyring_1.1-1_all.deb"
     sudo dpkg -i cuda-keyring_1.1-1_all.deb
     rm -f cuda-keyring_1.1-1_all.deb
     holodeck_retry 3 "$COMPONENT" sudo apt-get update


### PR DESCRIPTION
## Summary
- Replace hardcoded `x86_64` in CUDA repository URL with runtime `uname -m` detection
- Map `aarch64` → `sbsa` (NVIDIA's arm64 server CUDA repo convention)

## Test plan
- [x] Unit test verifies template output contains arch detection, not hardcoded x86_64
- [x] `go test ./pkg/provisioner/templates/... -v` passes
- [ ] CI validation pending