### PR TITLE
fix(aws): infer AMI architecture from instance type for arm64 support

### DIFF
--- a/pkg/provider/aws/cluster.go
+++ b/pkg/provider/aws/cluster.go
@@ -404,10 +404,15 @@ func (p *Provider) createInstances(
 		arch = image.Architecture
 	} else {
 		// Infer architecture from instance type (e.g., arm64 for g5g/m7g/c7g)
-		if inferred, err := p.inferArchFromInstanceType(instanceType); err == nil {
-			arch = inferred
+		inferred, err := p.inferArchFromInstanceType(instanceType)
+		if err != nil {
+			return nil, fmt.Errorf(
+				"failed to infer architecture from instance type %s: %w; set spec.image.architecture explicitly to override",
+				instanceType,
+				err,
+			)
 		}
-		// If inference fails, leave empty for resolveImageForNode to default
+		arch = inferred
 	}
 	resolved, err := p.resolveImageForNode(os, image, arch)
 	if err != nil {

--- a/pkg/provider/aws/image_test.go
+++ b/pkg/provider/aws/image_test.go
@@ -1063,7 +1063,7 @@ func TestInferArchFromInstanceType(t *testing.T) {
 		},
 		{
 			name:         "dual-arch instance type defaults to x86_64",
-			instanceType: "m6i.large",
+			instanceType: "synthetic.dualarch",
 			setupMock: func(ec2Mock *MockEC2Client) {
 				ec2Mock.DescribeInstTypesFunc = func(ctx context.Context,
 					params *ec2.DescribeInstanceTypesInput,
@@ -1071,11 +1071,59 @@ func TestInferArchFromInstanceType(t *testing.T) {
 					return &ec2.DescribeInstanceTypesOutput{
 						InstanceTypes: []types.InstanceTypeInfo{
 							{
-								InstanceType: "m6i.large",
+								InstanceType: "synthetic.dualarch",
 								ProcessorInfo: &types.ProcessorInfo{
 									SupportedArchitectures: []types.ArchitectureType{
 										types.ArchitectureTypeX8664,
 										types.ArchitectureTypeArm64,
+									},
+								},
+							},
+						},
+					}, nil
+				}
+			},
+			wantArch: "x86_64",
+			wantErr:  false,
+		},
+		{
+			name:         "arm64_mac variant infers arm64",
+			instanceType: "mac2-m2.metal",
+			setupMock: func(ec2Mock *MockEC2Client) {
+				ec2Mock.DescribeInstTypesFunc = func(ctx context.Context,
+					params *ec2.DescribeInstanceTypesInput,
+					optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
+					return &ec2.DescribeInstanceTypesOutput{
+						InstanceTypes: []types.InstanceTypeInfo{
+							{
+								InstanceType: "mac2-m2.metal",
+								ProcessorInfo: &types.ProcessorInfo{
+									SupportedArchitectures: []types.ArchitectureType{
+										types.ArchitectureTypeArm64Mac,
+									},
+								},
+							},
+						},
+					}, nil
+				}
+			},
+			wantArch: "arm64",
+			wantErr:  false,
+		},
+		{
+			name:         "x86_64_mac variant infers x86_64",
+			instanceType: "mac1.metal",
+			setupMock: func(ec2Mock *MockEC2Client) {
+				ec2Mock.DescribeInstTypesFunc = func(ctx context.Context,
+					params *ec2.DescribeInstanceTypesInput,
+					optFns ...func(*ec2.Options)) (*ec2.DescribeInstanceTypesOutput, error) {
+					return &ec2.DescribeInstanceTypesOutput{
+						InstanceTypes: []types.InstanceTypeInfo{
+							{
+								InstanceType: "mac1.metal",
+								ProcessorInfo: &types.ProcessorInfo{
+									SupportedArchitectures: []types.ArchitectureType{
+										types.ArchitectureTypeX8664Mac,
 									},
 								},
 							},


### PR DESCRIPTION
## Summary

- Add `inferArchFromInstanceType()` helper that queries `DescribeInstanceTypes` to detect arm64-only instance types
- Wire architecture inference into all three AMI resolution paths: `resolveOSToAMI` (single-node), `setLegacyAMI` (legacy default), and `createInstances` (cluster mode)
- When `image.architecture` is unset and the instance type only supports arm64 (e.g., `g5g`, `m7g`, `c7g`), holodeck now automatically resolves arm64 AMIs instead of defaulting to x86_64

### Root Cause

When a holodeck config specifies an arm64-only instance type (like `g5g.xlarge`) without explicitly setting `image.architecture: arm64`, holodeck unconditionally defaults to `x86_64`. This resolves an x86_64 AMI, and EC2 `RunInstances` rejects the mismatch:

```
api error Unsupported: The requested configuration is currently not supported.
```

The existing cross-validation (#664) catches this mismatch in `DryRun()` with a better error, but doesn't prevent it. This PR fixes the selection itself.

### Backward Compatibility

- Explicit `image.architecture` always takes precedence (no behavior change)
- Dual-arch or x86_64-only instance types still default to `x86_64` (no behavior change)
- Only arm64-only instance types trigger the new inference

### Supersedes

Closes the gap left by PRs #661-664 which addressed validation and provisioning but not AMI selection.
Related: https://github.com/NVIDIA/gpu-driver-container/actions/runs/22012665274/job/63611032634

## Test plan

- [x] `TestInferArchFromInstanceType` — arm64-only, x86_64-only, dual-arch, API error
- [x] `TestResolveOSToAMI_InfersArchFromInstanceType` — end-to-end: g5g.xlarge + empty arch → arm64 AMI
- [x] `go test ./pkg/provider/aws/... -v` — all 84 Ginkgo + unit tests pass
- [x] `go test ./pkg/... -count=1` — full package suite passes
- [x] `go vet ./pkg/provider/aws/...` — clean
- [ ] CI validation