### PR TITLE
fix(aws): validate instance type before creating resources

### DIFF
--- a/pkg/provider/aws/cluster.go
+++ b/pkg/provider/aws/cluster.go
@@ -99,6 +99,11 @@ func (p *Provider) CreateCluster() error {
 		return fmt.Errorf("cluster spec not defined, use Create() for single-node")
 	}
 
+	// Validate instance type before creating any resources (same rationale as Create())
+	if err := p.checkInstanceTypes(); err != nil {
+		return fmt.Errorf("pre-flight check failed: %w", err)
+	}
+
 	cache := &ClusterCache{}
 
 	_ = p.updateProgressingCondition(*p.DeepCopy(), &cache.AWS, "v1alpha1.Creating", "Creating multinode cluster resources")

--- a/pkg/provider/aws/create.go
+++ b/pkg/provider/aws/create.go
@@ -51,6 +51,15 @@ func (p *Provider) Create() error {
 	}
 
 	// Single-node deployment
+
+	// Validate instance type is available in the region before creating any
+	// resources. Without this check, VPC/subnet/IGW/etc. are created and then
+	// RunInstances fails with an opaque EC2 "Unsupported configuration" error,
+	// leaking resources that must be cleaned up manually.
+	if err := p.checkInstanceTypes(); err != nil {
+		return fmt.Errorf("pre-flight check failed: %w", err)
+	}
+
 	cache := new(AWS)
 	var cleanupStack []cleanupFunc
 	var err error


### PR DESCRIPTION
## Summary

- Add pre-flight `checkInstanceTypes()` call to `Create()` and `CreateCluster()` before any VPC/subnet/IGW resources are created
- Previously, an unsupported instance type (e.g., `g5g.xlarge` in `us-west-1`) would create all networking resources then fail at `RunInstances` with an opaque EC2 "Unsupported configuration" error, leaking resources
- Now fails immediately with: `"pre-flight check failed: instance type g5g.xlarge is not supported in the current region us-west-1"`

## Motivation

Discovered while investigating [gpu-driver-container CI failure](https://github.com/NVIDIA/gpu-driver-container/actions/runs/22054276692/job/63722809613) — ARM64 `g5g.xlarge` instances are not available in `us-west-1`, but the error from EC2 was indistinguishable from an architecture mismatch.

`DryRun()` already validates instance type availability, but `Create()` skipped this check entirely. The same `checkInstanceTypes()` function is now called in both create paths (single-node and cluster).

## Changes

| File | Description |
|------|-------------|
| `pkg/provider/aws/create.go` | Add `checkInstanceTypes()` before VPC creation in `Create()` |
| `pkg/provider/aws/cluster.go` | Add `checkInstanceTypes()` before VPC creation in `CreateCluster()` |
| `pkg/provider/aws/create_test.go` | New test: `Create()` fails fast with clear error and no leaked resources |

## Known limitation

The `CreateCluster()` pre-flight check validates `p.Spec.Type` (the top-level instance type), but cluster deployments may use different instance types per node pool (`Spec.Cluster.ControlPlane.InstanceType`, `Spec.Cluster.Workers[].InstanceType`). A follow-up should validate all cluster instance types before resource creation.

## Test plan

- [x] `go vet ./pkg/provider/aws/...` — clean
- [x] `go test ./pkg/provider/aws/...` — 84/84 Ginkgo specs pass, new unit test passes
- [x] New test verifies: (1) error mentions "instance type" and "not supported", (2) no VPC created (zero leaked resources)