### PR TITLE
feat(templates): add RPM support to NVIDIA driver

### DIFF
--- a/pkg/provisioner/templates/nv-driver.go
+++ b/pkg/provisioner/templates/nv-driver.go
@@ -82,7 +82,7 @@ case "${HOLODECK_OS_FAMILY}" in
     debian)
         holodeck_retry 3 "$COMPONENT" pkg_update
 
-        if ! apt-cache show "linux-headers-${KERNEL_VERSION}" >/dev/null 2>&1; then
+        if ! apt-cache show "linux-headers-${KERNEL_VERSION}" >/dev/null; then
             holodeck_log "WARN" "$COMPONENT" \
                 "Kernel headers for ${KERNEL_VERSION} not found in repositories"
 
@@ -118,7 +118,7 @@ case "${HOLODECK_OS_FAMILY}" in
     amazon|rhel)
         holodeck_retry 3 "$COMPONENT" pkg_update
 
-        if ! dnf list available "kernel-devel-${KERNEL_VERSION}" &>/dev/null 2>&1; then
+        if ! dnf list available "kernel-devel-${KERNEL_VERSION}" &>/dev/null; then
             holodeck_log "WARN" "$COMPONENT" \
                 "kernel-devel for ${KERNEL_VERSION} not found, trying generic kernel-devel"
             holodeck_retry 3 "$COMPONENT" install_packages_with_retry kernel-devel kernel-headers
@@ -301,7 +301,7 @@ case "${HOLODECK_OS_FAMILY}" in
     debian)
         holodeck_retry 3 "$COMPONENT" pkg_update
 
-        if ! apt-cache show "linux-headers-${KERNEL_VERSION}" >/dev/null 2>&1; then
+        if ! apt-cache show "linux-headers-${KERNEL_VERSION}" >/dev/null; then
             KERNEL_BASE=$(echo "${KERNEL_VERSION}" | cut -d- -f1-2)
             COMPATIBLE_HEADERS=$(apt-cache search linux-headers | \
                 grep -E "linux-headers-${KERNEL_BASE}" | head -1 | awk '{print $1}')
@@ -324,7 +324,7 @@ case "${HOLODECK_OS_FAMILY}" in
     amazon|rhel)
         holodeck_retry 3 "$COMPONENT" pkg_update
 
-        if ! dnf list available "kernel-devel-${KERNEL_VERSION}" &>/dev/null 2>&1; then
+        if ! dnf list available "kernel-devel-${KERNEL_VERSION}" &>/dev/null; then
             holodeck_log "WARN" "$COMPONENT" \
                 "kernel-devel for ${KERNEL_VERSION} not found, trying generic kernel-devel"
             holodeck_retry 3 "$COMPONENT" install_packages_with_retry kernel-devel kernel-headers
@@ -461,7 +461,7 @@ case "${HOLODECK_OS_FAMILY}" in
     debian)
         holodeck_retry 3 "$COMPONENT" pkg_update
 
-        if ! apt-cache show "linux-headers-${KERNEL_VERSION}" >/dev/null 2>&1; then
+        if ! apt-cache show "linux-headers-${KERNEL_VERSION}" >/dev/null; then
             KERNEL_BASE=$(echo "${KERNEL_VERSION}" | cut -d- -f1-2)
             COMPATIBLE_HEADERS=$(apt-cache search linux-headers | \
                 grep -E "linux-headers-${KERNEL_BASE}" | head -1 | awk '{print $1}')
@@ -488,7 +488,7 @@ case "${HOLODECK_OS_FAMILY}" in
     amazon|rhel)
         holodeck_retry 3 "$COMPONENT" pkg_update
 
-        if ! dnf list available "kernel-devel-${KERNEL_VERSION}" &>/dev/null 2>&1; then
+        if ! dnf list available "kernel-devel-${KERNEL_VERSION}" &>/dev/null; then
             holodeck_log "WARN" "$COMPONENT" \
                 "kernel-devel for ${KERNEL_VERSION} not found, trying generic kernel-devel"
             holodeck_retry 3 "$COMPONENT" install_packages_with_retry kernel-devel kernel-headers


### PR DESCRIPTION
## Summary
- Add OS-family branching to all 3 NVIDIA driver sub-templates (package, runfile, git)
- Debian path: linux-headers, build-essential, CUDA keyring .deb, `=` version pinning
- RPM path: kernel-devel, gcc/gcc-c++, CUDA .repo via curl, `-` version pinning
- Dynamic CUDA architecture detection (aarch64 → sbsa mapping)
- Uses `pkg_update` abstraction consistently across all branches

Part of #569 (Epic: Support RPM-Based Distributions)

## Test plan
- [x] All existing nv-driver tests pass
- [x] New tests: OSFamilyBranching for package, runfile, git templates
- [x] New tests: RPM kernel headers, RPM build deps, CUDA repo RPM setup
- [x] `go test ./pkg/provisioner/templates/ -count=1` passes
- [ ] E2E validation on Rocky Linux / Amazon Linux instance