### PR TITLE
feat(templates): add RPM support to CRI-O template

### DIFF
--- a/pkg/provisioner/templates/crio_test.go
+++ b/pkg/provisioner/templates/crio_test.go
@@ -117,7 +117,7 @@ func TestCriO_Execute_PackageSource(t *testing.T) {
 	assert.Contains(t, out, `COMPONENT="crio"`)
 	assert.Contains(t, out, `SOURCE="package"`)
 	assert.Contains(t, out, "holodeck_progress")
-	assert.Contains(t, out, "apt-get install -y cri-o")
+	assert.Contains(t, out, "pkg_install cri-o")
 	assert.Contains(t, out, "systemctl start crio.service")
 	assert.Contains(t, out, "holodeck_verify_crio")
 	assert.Contains(t, out, "holodeck_mark_installed")
@@ -143,4 +143,121 @@ func TestCriO_Execute_GitSource(t *testing.T) {
 	assert.Contains(t, out, "make install")
 	assert.Contains(t, out, "PROVENANCE.json")
 	assert.Contains(t, out, "holodeck_verify_crio")
+}
+
+// === RPM SUPPORT TESTS ===
+
+func TestCriO_Execute_PackageTemplate_OSFamilyBranching(t *testing.T) {
+	c := &CriO{
+		Source:  "package",
+		Version: "1.30",
+	}
+
+	var buf bytes.Buffer
+	err := c.Execute(&buf, v1alpha1.Environment{})
+	require.NoError(t, err)
+
+	out := buf.String()
+
+	// Must contain OS-family branching
+	assert.Contains(t, out, `case "${HOLODECK_OS_FAMILY}" in`,
+		"Package template must branch on HOLODECK_OS_FAMILY")
+	assert.Contains(t, out, "debian)",
+		"Package template must handle debian OS family")
+	assert.Contains(t, out, "amazon|rhel)",
+		"Package template must handle amazon and rhel OS families")
+
+	// Must contain unsupported OS family error
+	assert.Contains(t, out, "Unsupported OS family",
+		"Package template must error on unsupported OS families")
+}
+
+func TestCriO_Execute_PackageTemplate_DebianRepoSetup(t *testing.T) {
+	c := &CriO{
+		Source:  "package",
+		Version: "1.30",
+	}
+
+	var buf bytes.Buffer
+	err := c.Execute(&buf, v1alpha1.Environment{})
+	require.NoError(t, err)
+
+	out := buf.String()
+
+	// Debian still uses GPG keyring and apt sources
+	assert.Contains(t, out, "cri-o-apt-keyring.gpg",
+		"Package template must set up GPG keyring for Debian")
+	assert.Contains(t, out, "sources.list.d/cri-o.list",
+		"Package template must configure apt source for Debian")
+}
+
+func TestCriO_Execute_PackageTemplate_RPMRepoSetup(t *testing.T) {
+	c := &CriO{
+		Source:  "package",
+		Version: "1.30",
+	}
+
+	var buf bytes.Buffer
+	err := c.Execute(&buf, v1alpha1.Environment{})
+	require.NoError(t, err)
+
+	out := buf.String()
+
+	// RPM uses yum.repos.d
+	assert.Contains(t, out, "yum.repos.d",
+		"Package template must set up yum repo for RPM")
+	assert.Contains(t, out, "/rpm/",
+		"Package template must reference RPM repo URL")
+}
+
+func TestCriO_Execute_GitTemplate_OSFamilyBranching(t *testing.T) {
+	c := &CriO{
+		Source:    "git",
+		GitRepo:   "https://github.com/cri-o/cri-o.git",
+		GitRef:    "v1.30.0",
+		GitCommit: "abc12345",
+	}
+
+	var buf bytes.Buffer
+	err := c.Execute(&buf, v1alpha1.Environment{})
+	require.NoError(t, err)
+
+	out := buf.String()
+
+	// Git template must have OS-family branching for build deps
+	assert.Contains(t, out, `case "${HOLODECK_OS_FAMILY}" in`,
+		"Git template must branch on HOLODECK_OS_FAMILY")
+	assert.Contains(t, out, "debian)",
+		"Git template must handle debian OS family")
+	assert.Contains(t, out, "amazon|rhel)",
+		"Git template must handle amazon and rhel OS families")
+}
+
+func TestCriO_Execute_GitTemplate_RPMBuildDeps(t *testing.T) {
+	c := &CriO{
+		Source:    "git",
+		GitRepo:   "https://github.com/cri-o/cri-o.git",
+		GitRef:    "v1.30.0",
+		GitCommit: "abc12345",
+	}
+
+	var buf bytes.Buffer
+	err := c.Execute(&buf, v1alpha1.Environment{})
+	require.NoError(t, err)
+
+	out := buf.String()
+
+	// RPM build deps
+	assert.Contains(t, out, "libseccomp-devel",
+		"Git template must install libseccomp-devel for RPM")
+	assert.Contains(t, out, "gpgme-devel",
+		"Git template must install gpgme-devel for RPM")
+	assert.Contains(t, out, "glib2-devel",
+		"Git template must install glib2-devel for RPM")
+
+	// Debian build deps still present
+	assert.Contains(t, out, "libseccomp-dev",
+		"Git template must still install libseccomp-dev for Debian")
+	assert.Contains(t, out, "libgpgme-dev",
+		"Git template must still install libgpgme-dev for Debian")
 }


### PR DESCRIPTION
## Summary
- Add OS-family branching to CRI-O package and git template paths
- Debian: GPG key + apt sources for pkgs.k8s.io CRI-O repos (unchanged)
- RPM: dnf config-manager --add-repo for RPM CRI-O repos
- Build deps mapped: libseccomp-dev → libseccomp-devel, libgpgme-dev → gpgme-devel, libglib2.0-dev → glib2-devel
- `pkg_update`/`pkg_install` abstractions replace raw apt-get calls

Part of #569 (Epic: Support RPM-Based Distributions)

## Test plan
- [x] All existing CRI-O tests pass
- [x] New tests: OSFamilyBranching, Debian repo setup, RPM repo setup, git RPM build deps
- [x] `go test ./pkg/provisioner/templates/ -count=1` passes
- [ ] E2E validation on Rocky Linux / Amazon Linux instance