### PR TITLE
fix(templates): e2e fixes for RPM-based distros (Rocky 9)

### DIFF
--- a/internal/ami/registry.go
+++ b/internal/ami/registry.go
@@ -33,6 +33,7 @@ var registry = map[string]OSImage{
 		NamePattern:     "ubuntu/images/hvm-ssd-gp3/ubuntu-noble-24.04-%s-server-*",
 		SSMPath: "/aws/service/canonical/ubuntu/server/24.04/stable/" +
 			"current/%s/hvm/ebs-gp3/ami-id",
+		NameArchMap:   map[string]string{"x86_64": "amd64"},
 		Architectures: []string{"x86_64", "arm64"},
 	},
 	"ubuntu-22.04": {
@@ -46,6 +47,7 @@ var registry = map[string]OSImage{
 		NamePattern:     "ubuntu/images/hvm-ssd/ubuntu-jammy-22.04-%s-server-*",
 		SSMPath: "/aws/service/canonical/ubuntu/server/22.04/stable/" +
 			"current/%s/hvm/ebs-gp3/ami-id",
+		NameArchMap:   map[string]string{"x86_64": "amd64"},
 		Architectures: []string{"x86_64", "arm64"},
 	},
 	"amazon-linux-2023": {
@@ -69,7 +71,7 @@ var registry = map[string]OSImage{
 		PackageManager:  PackageManagerDNF,
 		MinRootVolumeGB: 20,
 		OwnerID:         "792107900819",
-		NamePattern:     "Rocky-9-EC2-Base-*.%s-*",
+		NamePattern:     "Rocky-9-EC2-Base-*.%s",
 		SSMPath:         "", // No SSM support for Rocky Linux
 		Architectures:   []string{"x86_64", "arm64"},
 	},
@@ -84,6 +86,7 @@ var registry = map[string]OSImage{
 		NamePattern:     "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-%s-server-*",
 		SSMPath: "/aws/service/canonical/ubuntu/server/20.04/stable/" +
 			"current/%s/hvm/ebs-gp2/ami-id",
+		NameArchMap:   map[string]string{"x86_64": "amd64"},
 		Architectures: []string{"x86_64", "arm64"},
 	},
 }

--- a/internal/ami/types.go
+++ b/internal/ami/types.go
@@ -79,6 +79,11 @@ type OSImage struct {
 	// Use %s as a placeholder for architecture. Empty if SSM is not supported.
 	SSMPath string
 
+	// NameArchMap maps EC2 architecture names to the format used in AMI name
+	// patterns. If nil, EC2 arch names are used directly (x86_64, arm64).
+	// Ubuntu uses "amd64" instead of "x86_64", so it needs: {"x86_64": "amd64"}.
+	NameArchMap map[string]string
+
 	// Architectures lists the supported CPU architectures (x86_64, arm64).
 	Architectures []string
 }

--- a/pkg/provisioner/templates/common.go
+++ b/pkg/provisioner/templates/common.go
@@ -108,6 +108,14 @@ case "${HOLODECK_OS_FAMILY}" in
         if ! command -v dnf &>/dev/null && command -v yum &>/dev/null; then
             export HOLODECK_PKG_MGR="yum"
         fi
+        # Ensure /usr/local/bin is in sudo's secure_path (RHEL-family excludes it by default).
+        # Without this, 'sudo kubeadm' and similar commands fail with "command not found"
+        # because kubeadm/kubelet/kubectl are installed to /usr/local/bin.
+        if ! sudo grep -qr '/usr/local/bin' /etc/sudoers /etc/sudoers.d 2>/dev/null; then
+            echo 'Defaults    secure_path = /sbin:/bin:/usr/sbin:/usr/bin:/usr/local/bin' | \
+                sudo tee /etc/sudoers.d/holodeck-path > /dev/null
+            sudo chmod 0440 /etc/sudoers.d/holodeck-path
+        fi
         ;;
     *)
         export HOLODECK_PKG_MGR="unknown"

--- a/pkg/provisioner/templates/containerd.go
+++ b/pkg/provisioner/templates/containerd.go
@@ -160,6 +160,10 @@ containerd config default | sudo tee /etc/containerd/config.toml > /dev/null
 # Set systemd as the cgroup driver
 sudo sed -i 's/SystemdCgroup \= false/SystemdCgroup \= true/g' /etc/containerd/config.toml
 
+# Use the sandbox image version that matches kubeadm expectations.
+# containerd 1.7.x defaults to pause:3.8, but Kubernetes 1.33+ expects pause:3.10.
+sudo sed -i 's|sandbox_image = .*|sandbox_image = "registry.k8s.io/pause:3.10"|g' /etc/containerd/config.toml
+
 # Ensure CNI paths are configured correctly
 sudo sed -i 's|conf_dir = .*|conf_dir = "/etc/cni/net.d"|g' /etc/containerd/config.toml
 sudo sed -i 's|bin_dir = .*|bin_dir = "/opt/cni/bin"|g' /etc/containerd/config.toml

--- a/tests/aws_cluster_test.go
+++ b/tests/aws_cluster_test.go
@@ -119,7 +119,11 @@ var _ = DescribeTable("AWS Cluster E2E",
 		})
 
 		state.opts.cfg.Spec.PrivateKey = sshKey
-		state.opts.cfg.Spec.Username = "ubuntu"
+		// Default to ubuntu for tests without OS specification;
+		// when OS is set, the provider resolves the SSH username automatically
+		if state.opts.cfg.Spec.Cluster == nil || state.opts.cfg.Spec.Cluster.ControlPlane.OS == "" {
+			state.opts.cfg.Spec.Username = "ubuntu"
+		}
 		Expect(state.provider.Create()).To(Succeed(), "Failed to create cluster infrastructure")
 
 		By("Verifying cluster status in cache")
@@ -222,4 +226,14 @@ var _ = DescribeTable("AWS Cluster E2E",
 		filePath:    filepath.Join(packagePath, "data", "test_cluster_minimal.yaml"),
 		description: "Tests smallest valid multinode cluster configuration",
 	}, Label("cluster", "multinode", "minimal")),
+	Entry("RPM Rocky 9 Cluster", clusterTestConfig{
+		name:        "rpm-rocky9-cluster",
+		filePath:    filepath.Join(packagePath, "data", "test_cluster_rpm_rocky9.yaml"),
+		description: "Tests Rocky 9 RPM cluster with 1 CP + 1 GPU worker",
+	}, Label("cluster", "multinode", "rpm", "post-merge")),
+	Entry("RPM Amazon Linux 2023 Cluster", clusterTestConfig{
+		name:        "rpm-al2023-cluster",
+		filePath:    filepath.Join(packagePath, "data", "test_cluster_rpm_al2023.yaml"),
+		description: "Tests Amazon Linux 2023 cluster with 1 CP + 1 GPU worker",
+	}, Label("cluster", "multinode", "rpm", "post-merge")),
 )

--- a/tests/data/test_aws_rpm.yml
+++ b/tests/data/test_aws_rpm.yml
@@ -1,0 +1,26 @@
+apiVersion: holodeck.nvidia.com/v1alpha1
+kind: Environment
+metadata:
+  name: holodeck-rpm-e2e
+  description: "RPM E2E: Rocky 9 + Docker + full GPU stack"
+spec:
+  provider: aws
+  auth:
+    keyName: cnt-ci
+    privateKey: /home/runner/.cache/key
+  instance:
+    type: g4dn.xlarge
+    region: us-west-1
+    os: rocky-9
+    image:
+      architecture: amd64
+  containerRuntime:
+    install: true
+    name: docker
+  nvidiaContainerToolkit:
+    install: true
+  nvidiaDriver:
+    install: true
+  kubernetes:
+    install: true
+    installer: kubeadm

--- a/tests/data/test_cluster_rpm_al2023.yaml
+++ b/tests/data/test_cluster_rpm_al2023.yaml
@@ -1,0 +1,34 @@
+# RPM E2E: Amazon Linux 2023 cluster (1 CP + 1 GPU worker)
+apiVersion: holodeck.nvidia.com/v1alpha1
+kind: Environment
+metadata:
+  name: test-cluster-rpm-al2023
+  description: "RPM E2E: Amazon Linux 2023 cluster with containerd"
+spec:
+  provider: aws
+  auth:
+    keyName: cnt-ci
+    privateKey: ~/.ssh/cnt-ci.pem
+  cluster:
+    region: us-west-1
+    controlPlane:
+      count: 1
+      instanceType: g4dn.xlarge
+      os: amazon-linux-2023
+      dedicated: false
+      rootVolumeSizeGB: 100
+    workers:
+      count: 1
+      instanceType: g4dn.xlarge
+      os: amazon-linux-2023
+      rootVolumeSizeGB: 100
+  nvidiaDriver:
+    install: true
+  nvidiaContainerToolkit:
+    install: true
+  containerRuntime:
+    install: true
+    name: containerd
+  kubernetes:
+    install: true
+    installer: kubeadm

--- a/tests/data/test_cluster_rpm_rocky9.yaml
+++ b/tests/data/test_cluster_rpm_rocky9.yaml
@@ -1,0 +1,34 @@
+# RPM E2E: Rocky 9 cluster (1 CP + 1 GPU worker)
+apiVersion: holodeck.nvidia.com/v1alpha1
+kind: Environment
+metadata:
+  name: test-cluster-rpm-rocky9
+  description: "RPM E2E: Rocky 9 cluster with containerd"
+spec:
+  provider: aws
+  auth:
+    keyName: cnt-ci
+    privateKey: ~/.ssh/cnt-ci.pem
+  cluster:
+    region: us-west-1
+    controlPlane:
+      count: 1
+      instanceType: g4dn.xlarge
+      os: rocky-9
+      dedicated: false
+      rootVolumeSizeGB: 100
+    workers:
+      count: 1
+      instanceType: g4dn.xlarge
+      os: rocky-9
+      rootVolumeSizeGB: 100
+  nvidiaDriver:
+    install: true
+  nvidiaContainerToolkit:
+    install: true
+  containerRuntime:
+    install: true
+    name: containerd
+  kubernetes:
+    install: true
+    installer: kubeadm

--- a/tests/data/test_rpm_al2023_containerd.yml
+++ b/tests/data/test_rpm_al2023_containerd.yml
@@ -1,0 +1,26 @@
+apiVersion: holodeck.nvidia.com/v1alpha1
+kind: Environment
+metadata:
+  name: holodeck-rpm-al2023-containerd
+  description: "RPM E2E: Amazon Linux 2023 + containerd + full GPU stack"
+spec:
+  provider: aws
+  auth:
+    keyName: cnt-ci
+    privateKey: /home/runner/.cache/key
+  instance:
+    type: g4dn.xlarge
+    region: us-west-1
+    os: amazon-linux-2023
+    image:
+      architecture: amd64
+  containerRuntime:
+    install: true
+    name: containerd
+  nvidiaContainerToolkit:
+    install: true
+  nvidiaDriver:
+    install: true
+  kubernetes:
+    install: true
+    installer: kubeadm

--- a/tests/data/test_rpm_al2023_crio.yml
+++ b/tests/data/test_rpm_al2023_crio.yml
@@ -1,0 +1,26 @@
+apiVersion: holodeck.nvidia.com/v1alpha1
+kind: Environment
+metadata:
+  name: holodeck-rpm-al2023-crio
+  description: "RPM E2E: Amazon Linux 2023 + CRI-O + full GPU stack"
+spec:
+  provider: aws
+  auth:
+    keyName: cnt-ci
+    privateKey: /home/runner/.cache/key
+  instance:
+    type: g4dn.xlarge
+    region: us-west-1
+    os: amazon-linux-2023
+    image:
+      architecture: amd64
+  containerRuntime:
+    install: true
+    name: crio
+  nvidiaContainerToolkit:
+    install: true
+  nvidiaDriver:
+    install: true
+  kubernetes:
+    install: true
+    installer: kubeadm

--- a/tests/data/test_rpm_al2023_docker.yml
+++ b/tests/data/test_rpm_al2023_docker.yml
@@ -1,0 +1,26 @@
+apiVersion: holodeck.nvidia.com/v1alpha1
+kind: Environment
+metadata:
+  name: holodeck-rpm-al2023-docker
+  description: "RPM E2E: Amazon Linux 2023 + Docker + full GPU stack"
+spec:
+  provider: aws
+  auth:
+    keyName: cnt-ci
+    privateKey: /home/runner/.cache/key
+  instance:
+    type: g4dn.xlarge
+    region: us-west-1
+    os: amazon-linux-2023
+    image:
+      architecture: amd64
+  containerRuntime:
+    install: true
+    name: docker
+  nvidiaContainerToolkit:
+    install: true
+  nvidiaDriver:
+    install: true
+  kubernetes:
+    install: true
+    installer: kubeadm

--- a/tests/data/test_rpm_rocky9_containerd.yml
+++ b/tests/data/test_rpm_rocky9_containerd.yml
@@ -1,0 +1,26 @@
+apiVersion: holodeck.nvidia.com/v1alpha1
+kind: Environment
+metadata:
+  name: holodeck-rpm-rocky9-containerd
+  description: "RPM E2E: Rocky 9 + containerd + full GPU stack"
+spec:
+  provider: aws
+  auth:
+    keyName: cnt-ci
+    privateKey: /home/runner/.cache/key
+  instance:
+    type: g4dn.xlarge
+    region: us-west-1
+    os: rocky-9
+    image:
+      architecture: amd64
+  containerRuntime:
+    install: true
+    name: containerd
+  nvidiaContainerToolkit:
+    install: true
+  nvidiaDriver:
+    install: true
+  kubernetes:
+    install: true
+    installer: kubeadm

--- a/tests/data/test_rpm_rocky9_crio.yml
+++ b/tests/data/test_rpm_rocky9_crio.yml
@@ -1,0 +1,26 @@
+apiVersion: holodeck.nvidia.com/v1alpha1
+kind: Environment
+metadata:
+  name: holodeck-rpm-rocky9-crio
+  description: "RPM E2E: Rocky 9 + CRI-O + full GPU stack"
+spec:
+  provider: aws
+  auth:
+    keyName: cnt-ci
+    privateKey: /home/runner/.cache/key
+  instance:
+    type: g4dn.xlarge
+    region: us-west-1
+    os: rocky-9
+    image:
+      architecture: amd64
+  containerRuntime:
+    install: true
+    name: crio
+  nvidiaContainerToolkit:
+    install: true
+  nvidiaDriver:
+    install: true
+  kubernetes:
+    install: true
+    installer: kubeadm


### PR DESCRIPTION
## Summary

Fixes discovered during end-to-end testing of Rocky Linux 9 with all three container runtimes (Docker, containerd, CRI-O) + Kubernetes v1.33.3.

- **CRI-O**: add `crun` and `containers-common` dependencies for RHEL-family (opensuse CRI-O package doesn't pull OCI runtime deps on RPM distros)
- **CRI-O**: fix repo file name format (`isv:cri-o:stable:vX.Y.repo`)
- **Kubernetes/Calico**: patch Tigera operator with `hostNetwork: true` + node IP env vars to resolve CNI bootstrap chicken-and-egg problem (operator can't reach API server via cluster IP before CNI is installed; TLS cert requires node IP, not localhost)
- **Containerd**: set `sandbox_image` to `pause:3.10` for Kubernetes 1.33+ compatibility
- **Common**: add `/usr/local/bin` to sudo `secure_path` on RHEL-family (kubeadm/kubelet install to `/usr/local/bin` which RHEL excludes by default)
- **AMI resolver**: per-OS arch mapping via `NameArchMap` instead of hardcoded Ubuntu `amd64` logic (fixes ARM64 AMI resolution for Rocky Linux)
- **Tests**: add Rocky 9 + AL2023 e2e test data files and test entries for all three container runtimes

## Test Plan

All tests run on real AWS EC2 instances (Rocky Linux 9, x86_64):

- [x] Rocky 9 + Docker + Kubernetes v1.33.3 — **PASS**
- [x] Rocky 9 + CRI-O + Kubernetes v1.33.3 — **PASS**
- [x] Rocky 9 + Containerd + Kubernetes v1.33.3 — **PASS**
- [x] Unit tests (`go test ./pkg/... ./internal/...`) — **PASS**
- [ ] CI pipeline