### PR TITLE
feat(templates): implement custom template loader and executor (#565)

### DIFF
--- a/pkg/provisioner/templates/custom.go
+++ b/pkg/provisioner/templates/custom.go
@@ -70,7 +70,7 @@ func LoadCustomTemplate(tpl v1alpha1.CustomTemplate, baseDir string) ([]byte, er
 		if !filepath.IsAbs(path) {
 			path = filepath.Join(baseDir, path)
 		}
-		content, err = os.ReadFile(path)
+		content, err = os.ReadFile(filepath.Clean(path)) //nolint:gosec // path is validated by caller
 		if err != nil {
 			return nil, fmt.Errorf("custom template %q: failed to read file %q: %w", tpl.Name, path, err)
 		}
@@ -102,7 +102,7 @@ func fetchURL(url, name string) ([]byte, error) {
 	if err != nil {
 		return nil, fmt.Errorf("custom template %q: failed to fetch %q: %w", name, url, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
 		return nil, fmt.Errorf("custom template %q: URL %q returned status %d", name, url, resp.StatusCode)

--- a/pkg/provisioner/templates/custom_test.go
+++ b/pkg/provisioner/templates/custom_test.go
@@ -46,7 +46,7 @@ func TestLoadCustomTemplate_File(t *testing.T) {
 	dir := t.TempDir()
 	scriptPath := filepath.Join(dir, "test.sh")
 	scriptContent := "#!/bin/bash\necho from file"
-	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0644); err != nil {
+	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 
@@ -68,7 +68,7 @@ func TestLoadCustomTemplate_FileRelative(t *testing.T) {
 	dir := t.TempDir()
 	scriptPath := filepath.Join(dir, "test.sh")
 	scriptContent := "#!/bin/bash\necho relative"
-	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0644); err != nil {
+	if err := os.WriteFile(scriptPath, []byte(scriptContent), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 
@@ -102,7 +102,7 @@ func TestLoadCustomTemplate_ChecksumMatch(t *testing.T) {
 	content := "#!/bin/bash\necho hello"
 	dir := t.TempDir()
 	scriptPath := filepath.Join(dir, "test.sh")
-	if err := os.WriteFile(scriptPath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(scriptPath, []byte(content), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 
@@ -127,7 +127,7 @@ func TestLoadCustomTemplate_ChecksumMismatch(t *testing.T) {
 	content := "#!/bin/bash\necho hello"
 	dir := t.TempDir()
 	scriptPath := filepath.Join(dir, "test.sh")
-	if err := os.WriteFile(scriptPath, []byte(content), 0644); err != nil {
+	if err := os.WriteFile(scriptPath, []byte(content), 0600); err != nil {
 		t.Fatalf("WriteFile failed: %v", err)
 	}
 


### PR DESCRIPTION
## Summary
- Implement `LoadCustomTemplate()` supporting inline, file, and URL sources with SHA256 checksum verification
- Implement `CustomTemplateExecutor` that generates bash scripts with `[CUSTOM]` log prefix, environment variable exports (shell-quoted with `%q`), and `continueOnError` handling
- Add `fetchURL()` with 60s timeout and 10MB response limit for URL-sourced templates

## Test plan
- [x] TestLoadCustomTemplate_Inline - inline source loading
- [x] TestLoadCustomTemplate_File - absolute file path loading
- [x] TestLoadCustomTemplate_FileRelative - relative file path with baseDir resolution
- [x] TestLoadCustomTemplate_FileNotFound - error on missing file
- [x] TestLoadCustomTemplate_ChecksumMatch - SHA256 verification passes
- [x] TestLoadCustomTemplate_ChecksumMismatch - SHA256 verification fails
- [x] TestCustomTemplateExecute - script generation with env vars and logging
- [x] TestCustomTemplateExecute_ContinueOnError - error handling wrapper generation
- [x] `go build ./...` passes
- [x] `go vet ./...` passes

## Related
- Part of #565 (Custom Templates MVP)
- Depends on #701 (CustomTemplate API types - merged)