### PR TITLE
feat(validate): add custom template input validation (#565)

### DIFF
--- a/pkg/provisioner/templates/validate.go
+++ b/pkg/provisioner/templates/validate.go
@@ -48,6 +48,9 @@ var (
 
 	// checksumPattern matches "sha256:<64 hex chars>"
 	checksumPattern = regexp.MustCompile(`^sha256:[a-fA-F0-9]{64}$`)
+
+	// envVarKeyPattern matches valid environment variable names.
+	envVarKeyPattern = regexp.MustCompile(`^[a-zA-Z_][a-zA-Z0-9_]*$`)
 )
 
 // ValidateTemplateInputs validates user-supplied fields that will be interpolated
@@ -232,14 +235,23 @@ func validateCustomTemplates(templates []v1alpha1.CustomTemplate) error {
 			if !filePathPattern.MatchString(tpl.File) {
 				return fmt.Errorf("custom template %q: file path %q contains disallowed characters", tpl.Name, tpl.File)
 			}
-			if strings.Contains(tpl.File, "..") {
-				return fmt.Errorf("custom template %q: file path %q contains path traversal", tpl.Name, tpl.File)
+			for _, part := range strings.Split(tpl.File, "/") {
+				if part == ".." {
+					return fmt.Errorf("custom template %q: file path %q contains path traversal", tpl.Name, tpl.File)
+				}
 			}
 		}
 
 		// Validate checksum format
 		if tpl.Checksum != "" && !checksumPattern.MatchString(tpl.Checksum) {
 			return fmt.Errorf("custom template %q: checksum must be in format sha256:<64 hex chars>", tpl.Name)
+		}
+
+		// Validate env var keys
+		for k := range tpl.Env {
+			if !envVarKeyPattern.MatchString(k) {
+				return fmt.Errorf("custom template %q: invalid env var name %q (must match [a-zA-Z_][a-zA-Z0-9_]*)", tpl.Name, k)
+			}
 		}
 	}
 	return nil

--- a/pkg/provisioner/templates/validate_test.go
+++ b/pkg/provisioner/templates/validate_test.go
@@ -424,3 +424,57 @@ func TestValidateTemplateInputs_CustomTemplates_DuplicateNames(t *testing.T) {
 		t.Errorf("unexpected error: %v", err)
 	}
 }
+
+func TestValidateTemplateInputs_CustomTemplates_InvalidEnvKey(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			CustomTemplates: []v1alpha1.CustomTemplate{
+				{
+					Name:   "bad-env",
+					Inline: "echo hello",
+					Env:    map[string]string{"FOO;rm -rf /": "bar"},
+				},
+			},
+		},
+	}
+	err := ValidateTemplateInputs(env)
+	if err == nil {
+		t.Fatal("expected error for invalid env var key")
+	}
+	if !strings.Contains(err.Error(), "invalid env var name") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestValidateTemplateInputs_CustomTemplates_ValidEnvKey(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			CustomTemplates: []v1alpha1.CustomTemplate{
+				{
+					Name:   "good-env",
+					Inline: "echo hello",
+					Env:    map[string]string{"MY_VAR": "value", "_PRIVATE": "secret"},
+				},
+			},
+		},
+	}
+	if err := ValidateTemplateInputs(env); err != nil {
+		t.Errorf("expected no error for valid env keys, got: %v", err)
+	}
+}
+
+func TestValidateTemplateInputs_CustomTemplates_DoubleDotFilename(t *testing.T) {
+	env := v1alpha1.Environment{
+		Spec: v1alpha1.EnvironmentSpec{
+			CustomTemplates: []v1alpha1.CustomTemplate{
+				{
+					Name: "double-dot-name",
+					File: "foo..bar.sh",
+				},
+			},
+		},
+	}
+	if err := ValidateTemplateInputs(env); err != nil {
+		t.Errorf("expected no error for filename with consecutive dots, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `validateCustomTemplates()` to validate user-supplied custom templates before shell interpolation
- Validates: name required, no duplicates, valid phase, exactly one source (inline/file/url), HTTPS-only URLs, safe file paths (no traversal), SHA256 checksum format
- Integrates with existing `ValidateTemplateInputs()` pipeline
- Part of custom templates feature (#565), follows Task 0 API types (#701)

## Test plan
- [x] 9 new test cases covering all validation rules
- [x] All existing validation tests continue to pass
- [x] `go build ./...` passes
- [x] `go vet ./...` passes