### PR TITLE
fix: remove kubeadm config cleanup that races in cluster mode

### DIFF
--- a/pkg/provisioner/provisioner.go
+++ b/pkg/provisioner/provisioner.go
@@ -410,9 +410,6 @@ func (p *Provisioner) createKubeAdmConfig(env v1alpha1.Environment) error {
 	}
 	_ = session.Close()
 
-	// Clean up the local temporary file — it's already on the remote host
-	_ = os.Remove(localFilePath)
-
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- PR #717 added `os.Remove()` after SCP to clean up local kubeadm config files
- In cluster mode, `provisionBaseOnAllNodes()` runs all nodes in parallel — each calls `createKubeAdmConfig()` with the same env name
- When one node deletes the file after SCP, other nodes fail with "no such file or directory"
- Remove the cleanup: `os.WriteFile` overwrites on each call, files are ~1KB in a cache dir

## Root Cause
`1CP + 3GPU Workers` cluster test failed because the control plane goroutine deleted `kubeadm-config-<env>.yaml` before the worker goroutine could read it.

## Test plan
- [ ] All existing unit tests pass
- [ ] Re-run cluster e2e tests: `minimal`, `3gpu`, `1cp-3gpu`, `ha`
- [ ] Verify `1cp-3gpu` (the failing test) now passes