### PR TITLE
feat: cleanup dual security groups on cluster delete

### DIFF
--- a/pkg/provider/aws/delete.go
+++ b/pkg/provider/aws/delete.go
@@ -270,7 +270,10 @@ func (p *Provider) deleteSecurityGroups(cache *AWS) error {
 		return fmt.Errorf("error deleting control-plane security group %s: %w", cache.CPSecurityGroupid, err)
 	}
 
-	// Delete the shared/single-node SG
+	// Delete the shared/single-node SG (skip if same as CP SG — cluster mode sets them equal)
+	if cache.SecurityGroupid == cache.CPSecurityGroupid {
+		cache.SecurityGroupid = "" // already deleted above
+	}
 	if err := p.deleteSecurityGroup(cache.SecurityGroupid, "shared"); err != nil {
 		if err := p.updateDegradedCondition(*p.DeepCopy(), cache, "v1alpha1.Destroying", "Error deleting security group"); err != nil {
 			p.log.Error(fmt.Errorf("failed to update degraded condition: %w", err))

--- a/pkg/provider/aws/delete_test.go
+++ b/pkg/provider/aws/delete_test.go
@@ -476,3 +476,46 @@ func TestDeleteSecurityGroups_AllEmpty(t *testing.T) {
 		t.Fatalf("expected no error when all SG IDs are empty, got: %v", err)
 	}
 }
+
+func TestDeleteSecurityGroups_SharedSameAsCP(t *testing.T) {
+	// When SecurityGroupid == CPSecurityGroupid (single-node mode where both
+	// point to the same SG), the shared SG should NOT be double-deleted.
+	var deletedSGs []string
+	mock := &MockEC2Client{
+		DeleteSGFunc: func(ctx context.Context, params *ec2.DeleteSecurityGroupInput, optFns ...func(*ec2.Options)) (*ec2.DeleteSecurityGroupOutput, error) {
+			deletedSGs = append(deletedSGs, aws.ToString(params.GroupId))
+			return &ec2.DeleteSecurityGroupOutput{}, nil
+		},
+		DescribeSGsFunc: func(ctx context.Context, params *ec2.DescribeSecurityGroupsInput, optFns ...func(*ec2.Options)) (*ec2.DescribeSecurityGroupsOutput, error) {
+			return nil, fmt.Errorf("InvalidGroup.NotFound")
+		},
+	}
+
+	env := testEnvironment()
+	provider := &Provider{
+		ec2:         mock,
+		log:         mockLogger(),
+		Environment: env,
+	}
+
+	cache := &AWS{
+		SecurityGroupid:       "sg-same-001",
+		CPSecurityGroupid:     "sg-same-001",
+		WorkerSecurityGroupid: "sg-worker-002",
+	}
+
+	if err := provider.deleteSecurityGroups(cache); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Should delete worker and CP, but NOT double-delete the shared SG
+	if len(deletedSGs) != 2 {
+		t.Fatalf("expected 2 delete calls, got %d: %v", len(deletedSGs), deletedSGs)
+	}
+	if deletedSGs[0] != "sg-worker-002" {
+		t.Errorf("first delete should be worker SG, got %s", deletedSGs[0])
+	}
+	if deletedSGs[1] != "sg-same-001" {
+		t.Errorf("second delete should be CP SG (same as shared), got %s", deletedSGs[1])
+	}
+}


### PR DESCRIPTION
## Summary
- Delete Worker SG before CP SG (dependency order)
- Handle empty SG IDs gracefully (backward compat)
- Extracted `deleteSecurityGroup()` helper with retry/backoff
- IAM profile cleanup deferred to Wave 3 (no IAM client yet)

## Test plan
- [x] Unit tests for dual SG cleanup ordering
- [x] Unit tests for empty/not-found edge cases
- [x] `go vet ./...` clean
- [ ] CI green