### PR TITLE
docs: update multinode cluster guide with production-grade networking

### DIFF
--- a/docs/guides/multinode-clusters.md
+++ b/docs/guides/multinode-clusters.md
@@ -221,7 +221,7 @@ Example files are available in `examples/`:
 Cluster mode creates a production-grade VPC topology with public and private
 subnets, a NAT gateway for outbound internet, and an NLB for API server access.
 
-```
+```text
 ┌──────────────────────────────── VPC 10.0.0.0/16 ────────────────────────────────┐
 │                                                                                  │
 │  ┌─── Public Subnet 10.0.1.0/24 ───┐    ┌─── Private Subnet 10.0.0.0/24 ───┐  │
@@ -324,9 +324,9 @@ ssh -i key.pem -p 2222 ubuntu@localhost
 ### Nodes not joining
 
 1. Check security group rules allow inter-node communication (see tables above)
-2. Verify the NAT gateway is active — nodes need outbound internet to pull
+1. Verify the NAT gateway is active — nodes need outbound internet to pull
    container images and join the cluster
-3. Check that the NLB health check on port 6443 is healthy
+1. Check that the NLB health check on port 6443 is healthy
 
 ### SSH to debug
 


### PR DESCRIPTION
## Summary

- Add VPC topology diagram showing public/private subnet architecture
- Document security group rules for control-plane and worker nodes
- Add SSM port-forwarding instructions for SSH access to private nodes
- Add single-node vs cluster comparison table
- Update troubleshooting for NAT gateway and SSM-based access

Part of the production-grade cluster networking project (Tasks 0-9).

## Test plan

- [ ] Verify markdown renders correctly
- [ ] Verify docs-check lint passes