### PR TITLE
build: expand test coverage scope to cmd/, api/, and internal/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ verify:
 
 COVERAGE_FILE := coverage.out
 test:
-	go test -coverprofile=$(COVERAGE_FILE) ./pkg/...
+	go test -coverprofile=$(COVERAGE_FILE) ./pkg/... ./cmd/... ./api/... ./internal/...
 
 coverage: test
 	go tool cover -func=$(COVERAGE_FILE)


### PR DESCRIPTION
## Summary

- Extends the `test` Makefile target to run `go test` with coverage across all four package trees: `./pkg/...`, `./cmd/...`, `./api/...`, and `./internal/...`
- All three new directories contain test files that were previously excluded from the Coveralls report
- No changes to the CI workflow: `.github/workflows/golang.yaml` already delegates to `make coverage`

## Packages with test files added to coverage scope

- `cmd/cli/` - 12 test files (dryrun, update, delete, status, describe, common, cleanup, list, scp, create)
- `api/holodeck/v1alpha1/` - 2 test files (types, validation)
- `internal/` - 3 test files (ami/resolver, logger, instances)

## Test plan

- [ ] `make coverage` passes with the expanded scope
- [ ] Coveralls report shows coverage data from cmd/, api/, and internal/ packages
- [ ] CI green on GitHub Actions