### PR TITLE
docs: add E2E test tier documentation to contributing guide

### DIFF
--- a/docs/contributing/README.md
+++ b/docs/contributing/README.md
@@ -124,10 +124,9 @@ Each job takes roughly 20 minutes, giving fast feedback before merge.
 
 **Full tier (post-merge)** — `.github/workflows/e2e.yaml`
 
-Runs only when a commit lands on `main`
-(`github.ref == 'refs/heads/main'`). Covers 13 label filters plus an
-arm64 job and an integration-test job that exercises holodeck as a
-GitHub Action.
+Runs only when a commit lands on `main` or a `release-*` branch.
+Covers 13 label filters plus a separate arm64 job and an
+integration-test job that exercises holodeck as a GitHub Action.
 
 | Label filter | What it covers |
 |---|---|
@@ -144,7 +143,10 @@ GitHub Action.
 | `rpm-rocky` | Rocky Linux 9 — multiple container runtimes |
 | `rpm-al2023` | Amazon Linux 2023 — multiple container runtimes |
 | `rpm-fedora` | Fedora 42 — multiple container runtimes |
-| `arm64` | ARM64 GPU instance (g5g) — run separately |
+
+The `arm64` job is a separate workflow job (not a matrix entry) that only
+runs on `main`. It uses `--label-filter='arm64'` — a test must carry
+`Label("arm64")` to be selected.
 
 ### Label Taxonomy
 
@@ -246,8 +248,8 @@ export AWS_SECRET_ACCESS_KEY=<your-secret>
 export E2E_SSH_KEY=<path-to-ssh-private-key>
 ```
 
-See [Memory: no push without local E2E validation](../../.claude/memory/) for
-the project policy on validating E2E tests before opening a PR.
+> **Important:** Always validate E2E tests locally before pushing. CI E2E
+> runs provision real GPU instances on AWS, and unnecessary runs are expensive.
 
 ## Documentation
 


### PR DESCRIPTION
## Summary

- Documents the two-tier E2E test system (smoke pre-merge, full post-merge) introduced in PR #740
- Adds a Label Taxonomy reference table covering all single-node and cluster labels
- Explains the `post-merge` label convention and provides guidance on which tier new tests should target
- Includes a "Running E2E Tests Locally" section with example `make` commands

## Test plan

- [ ] Verify rendered Markdown tables display correctly in GitHub UI
- [ ] Confirm all labels listed match `tests/aws_test.go` and `tests/aws_cluster_test.go`
- [ ] Confirm smoke/full tier label filters match workflow YAML files