### PR TITLE
release: bump version to v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this project will be documented in this file.
 
-## [v0.3.0] - Unreleased
+## [v0.3.0] - 2026-03-30
 
 ### Features
 

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -94,7 +94,7 @@ Examples:
 
   # Use a custom cache directory
   holodeck --cachepath /path/to/cache create -f env.yaml`
-	c.Version = "0.2.18"
+	c.Version = "0.3.0"
 	c.EnableBashCompletion = true
 
 	// Setup the flags for this command


### PR DESCRIPTION
## Summary

- Bump version string from `0.2.18` to `0.3.0` in `cmd/cli/main.go`
- Set CHANGELOG date from `Unreleased` to `2026-03-30`

## What's in v0.3.0

This is a major release covering all work since v0.2.18 (2025-12-13):

- **Production-Grade Cluster Networking** — private subnets, SSM transport, separate security groups, NLB for HA (#720-728)
- **Custom Templates** — user-provided scripts at provisioning phases (#701-706)
- **RPM Distribution Support** — Rocky Linux, Amazon Linux 2023, Fedora 42 (#676-681)
- **E2E Test Tiering** — smoke (pre-merge) and full (post-merge) tiers (#740)
- **ARM64 Support** — architecture inference from instance type (#669)
- **Comprehensive Documentation** — guides for custom templates, GitHub Action, multinode clusters, E2E testing
- **Test Infrastructure** — expanded coverage scope, 40% threshold gate, custom templates E2E
- **Dependency Updates** — AWS SDK v2 bumps (#741-745)

## Test plan

- [ ] Verify `holodeck --version` shows `0.3.0`
- [ ] CI passes (unit tests, lint, build)