### PR TITLE
fix: use grep -w for exact IP matching in cluster node configuration

### DIFF
--- a/pkg/provisioner/cluster.go
+++ b/pkg/provisioner/cluster.go
@@ -514,7 +514,7 @@ func (cp *ClusterProvisioner) configureNodes(firstCP NodeInfo, nodes []NodeInfo)
 		fmt.Fprintf(&script, "echo 'Configuring control-plane node with IP %s...'\n", node.PrivateIP)
 
 		// Get the actual node name from private IP
-		fmt.Fprintf(&script, "CP_NODE=$(sudo -E kubectl get nodes -o wide --no-headers | grep '%s' | awk '{print $1}')\n", node.PrivateIP)
+		fmt.Fprintf(&script, "CP_NODE=$(sudo -E kubectl get nodes -o wide --no-headers | grep -w '%s' | awk '{print $1}')\n", node.PrivateIP)
 		script.WriteString("if [ -n \"$CP_NODE\" ]; then\n")
 
 		// Apply control-plane labels
@@ -547,7 +547,7 @@ func (cp *ClusterProvisioner) configureNodes(firstCP NodeInfo, nodes []NodeInfo)
 		fmt.Fprintf(&script, "echo 'Configuring worker node with IP %s...'\n", node.PrivateIP)
 
 		// Get the actual node name from private IP
-		fmt.Fprintf(&script, "WORKER_NODE=$(sudo -E kubectl get nodes -o wide --no-headers | grep '%s' | awk '{print $1}')\n", node.PrivateIP)
+		fmt.Fprintf(&script, "WORKER_NODE=$(sudo -E kubectl get nodes -o wide --no-headers | grep -w '%s' | awk '{print $1}')\n", node.PrivateIP)
 		script.WriteString("if [ -n \"$WORKER_NODE\" ]; then\n")
 
 		// Apply worker role label


### PR DESCRIPTION
## Summary

- Fix partial IP matching bug in `configureNodes()` where `grep '10.0.1.8'` would match both `10.0.1.8` and `10.0.1.81`, concatenating two node names with a newline
- Add `-w` flag to grep for word-boundary matching on both control-plane and worker node lookups

## Root Cause

When a cluster has nodes with similar IP prefixes (e.g., `10.0.1.8` and `10.0.1.81`), the grep pattern matches both lines. The variable assignment captures both results with an embedded newline, causing `kubectl label node` to fail with:
```
Error from server (NotFound): nodes "ip-10-0-1-8\nip-10-0-1-81" not found
```

## Test plan

- [ ] Cluster E2E test passes (`cluster && dedicated` label)
- [ ] Existing unit tests pass (`go test ./pkg/provisioner/...`)

Fixes #756