### PR TITLE
ci: update periodic cleanup to v0.3.0 and add manual trigger

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -4,6 +4,7 @@ name: Periodic actions
 # It uses the holodeck cleanup command to remove VPCs tagged with Project=holodeck and Environment=cicd
 
 on:
+  workflow_dispatch: {}
   schedule:
     - cron: '0 0,12 * * *' # Runs daily at 12AM and 12PM
 
@@ -38,7 +39,7 @@ jobs:
 
       - name: Clean up VPCs
         if: steps.identify-resources.outputs.AWS_VPC_IDS != ''
-        uses: NVIDIA/holodeck@v0.2.18
+        uses: NVIDIA/holodeck@v0.3.0
         with:
           action: cleanup
           vpc_ids: ${{ steps.identify-resources.outputs.AWS_VPC_IDS }}


### PR DESCRIPTION
## Summary

- Update `NVIDIA/holodeck@v0.2.18` → `@v0.3.0` in periodic cleanup workflow — the old tag didn't have the cleanup action inputs, causing every run to fail
- Add `workflow_dispatch` trigger so cleanup can be run manually (e.g., when VPC limits are hit during CI)

## Test plan

- [ ] Merge PR, then trigger workflow manually via Actions tab
- [ ] Verify VPC cleanup runs successfully in both us-west-1 and us-east-1