### PR TITLE
fix: switch HA NLB to internal scheme to fix hairpin routing

### DIFF
--- a/pkg/provider/aws/nlb.go
+++ b/pkg/provider/aws/nlb.go
@@ -54,15 +54,16 @@ func (p *Provider) createNLB(cache *ClusterCache) error {
 	}
 	lbName := nlbBaseName + nlbSuffix
 
-	// Use the public subnet for the internet-facing NLB
+	// Use the public subnet for the internal NLB (same subnet as instances)
 	subnetIDs := []string{cache.PublicSubnetid}
 
-	// Create load balancer
+	// Create load balancer — internal scheme avoids hairpin routing issues
+	// where nodes connecting to the NLB's public IP get i/o timeouts
 	createLBInput := &elasticloadbalancingv2.CreateLoadBalancerInput{
 		Name:          aws.String(lbName),
 		Type:          lbType,
 		Subnets:       subnetIDs,
-		Scheme:        elbv2types.LoadBalancerSchemeEnumInternetFacing,
+		Scheme:        elbv2types.LoadBalancerSchemeEnumInternal,
 		IpAddressType: elbv2types.IpAddressTypeIpv4,
 		Tags:          p.convertTagsToELBv2Tags(),
 	}

--- a/pkg/provisioner/templates/kubeadm_cluster.go
+++ b/pkg/provisioner/templates/kubeadm_cluster.go
@@ -153,23 +153,6 @@ fi
 
 # Initialize cluster
 if [[ ! -f /etc/kubernetes/admin.conf ]]; then
-    # Wait for control-plane endpoint to be resolvable (NLB DNS may take time)
-    if [[ "$CONTROL_PLANE_ENDPOINT" == *"elb.amazonaws.com"* ]] || \
-       [[ "$CONTROL_PLANE_ENDPOINT" == *"amazonaws.com"* ]]; then
-        holodeck_log "INFO" "$COMPONENT" "Waiting for NLB DNS to resolve: ${CONTROL_PLANE_ENDPOINT}"
-        for i in {1..30}; do
-            if host "${CONTROL_PLANE_ENDPOINT}" &>/dev/null || \
-               getent hosts "${CONTROL_PLANE_ENDPOINT}" &>/dev/null; then
-                holodeck_log "INFO" "$COMPONENT" "NLB DNS resolved successfully"
-                break
-            fi
-            if [[ $i -eq 30 ]]; then
-                holodeck_log "WARN" "$COMPONENT" "NLB DNS not yet resolved after 5 min, proceeding anyway"
-            fi
-            sleep 10
-        done
-    fi
-
     INIT_ARGS=(
         --kubernetes-version="${K8S_VERSION}"
         --pod-network-cidr=192.168.0.0/16


### PR DESCRIPTION
## Summary

- Switch NLB from internet-facing to internal to fix hairpin routing that causes `dial tcp ...:6443: i/o timeout` in HA clusters
- Remove NLB DNS propagation wait (internal NLBs resolve immediately via VPC DNS)

## Root Cause

When a control-plane node connects to the NLB via its public DNS after kubeconfig switchover, the packet goes node → IGW → NLB → same node. AWS NLBs don't support this hairpin routing, so the connection times out.

## Test plan

- [ ] `cluster && ha` E2E test passes (post-merge)
- [ ] Existing unit tests pass
- [ ] `go build ./...` clean

Fixes #746