### PR TITLE
release: bump version to v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.3.1] - 2026-03-31
+
+### Bug Fixes
+
+- **fix: HA NLB hairpin routing (#746, #762)** — Control-plane nodes now use `localhost:6443` for kubectl instead of the NLB endpoint, avoiding AWS NLB hairpin/loopback timeouts where a registered target connects through the NLB and gets routed back to itself.
+- **fix: switch HA NLB to internal scheme (#760)** — NLB uses internal scheme to keep traffic within the VPC.
+- **fix: NLB cleanup in periodic VPC cleaner (#762)** — `DeleteVPCResources` now deletes NLB listeners, target groups, and load balancers before attempting subnet/IGW/VPC deletion, preventing `DependencyViolation` errors from NLB-owned ENIs.
+
+### CI
+
+- **ci: update periodic cleanup to v0.3.0 and add manual trigger (#758)** — Periodic cleanup workflow uses the latest holodeck binary and supports manual dispatch.
+
 ## [v0.3.0] - 2026-03-30
 
 ### Features

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -39,6 +39,8 @@ import (
 const (
 	// ProgramName is the canonical name of this program
 	ProgramName = "holodeck"
+	// ProgramVersion is the current version of the program
+	ProgramVersion = "0.3.1"
 )
 
 type config struct {
@@ -94,7 +96,7 @@ Examples:
 
   # Use a custom cache directory
   holodeck --cachepath /path/to/cache create -f env.yaml`
-	c.Version = "0.3.0"
+	c.Version = ProgramVersion
 	c.EnableBashCompletion = true
 
 	// Setup the flags for this command

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package main
+
+import (
+	"testing"
+)
+
+func TestVersion(t *testing.T) {
+	expected := "0.3.1"
+	if ProgramVersion != expected {
+		t.Errorf("expected version %q, got %q", expected, ProgramVersion)
+	}
+}


### PR DESCRIPTION
## v0.3.1 Patch Release

Patch release with critical fixes for HA NLB hairpin routing and VPC cleanup.

### Changes since v0.3.0

**Bug Fixes:**
- **HA NLB hairpin routing (#746, #762)** — CP nodes now use `localhost:6443` for kubectl instead of the NLB endpoint, avoiding AWS NLB hairpin/loopback timeouts.
- **NLB internal scheme (#760)** — NLB uses internal scheme to keep traffic within VPC.
- **NLB cleanup in periodic VPC cleaner (#762)** — `DeleteVPCResources` now deletes NLB resources before subnet/IGW/VPC deletion, preventing `DependencyViolation` errors.

**CI:**
- **Periodic cleanup update (#758)** — Uses latest holodeck binary and supports manual dispatch.

### Commits
- e3e086c2 ci: update periodic cleanup to v0.3.0 and add manual trigger (#758)
- cd30218c fix: switch HA NLB to internal scheme to fix hairpin routing (#746) (#760)
- 41454b94 fix: HA NLB hairpin routing and cleanup (#746) (#762)
- 238f3881 release: bump version to v0.3.1

Closes #761