### PR TITLE
release: bump version to v0.3.2

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Clean up VPCs
         if: steps.identify-resources.outputs.AWS_VPC_IDS != ''
-        uses: NVIDIA/holodeck@v0.3.1
+        uses: NVIDIA/holodeck@v0.3.2
         with:
           action: cleanup
           vpc_ids: ${{ steps.identify-resources.outputs.AWS_VPC_IDS }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.3.2] - 2026-03-31
+
+### Bug Fixes
+
+- **fix: revoke cross-referencing SG rules before deletion in cleanup (#766)** — Security groups that reference each other (e.g., CP SG allows traffic from Worker SG and vice versa) are now cleaned up by revoking all ingress/egress rules before attempting deletion, fixing `DependencyViolation` errors in periodic VPC cleanup.
+
+### CI
+
+- **ci: update periodic cleanup to v0.3.1 (#765)** — Periodic cleanup workflow updated to use v0.3.1 with NLB cleanup support.
+
 ## [v0.3.1] - 2026-03-31
 
 ### Bug Fixes

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -40,7 +40,7 @@ const (
 	// ProgramName is the canonical name of this program
 	ProgramName = "holodeck"
 	// ProgramVersion is the current version of the program
-	ProgramVersion = "0.3.1"
+	ProgramVersion = "0.3.2"
 )
 
 type config struct {
@@ -49,11 +49,10 @@ type config struct {
 	Quiet   bool
 }
 
-func main() {
-	config := config{}
-	log := logger.NewLogger()
+// NewApp creates and configures the CLI application.
+func NewApp(log *logger.FunLogger) *cli.App {
+	cfg := config{}
 
-	// Create the top-level CLI
 	c := cli.NewApp()
 	c.Name = ProgramName
 	c.Usage = "Create and manage test environments"
@@ -105,18 +104,18 @@ Examples:
 			Name:        "quiet",
 			Aliases:     []string{"q"},
 			Usage:       "Suppress non-error output",
-			Destination: &config.Quiet,
+			Destination: &cfg.Quiet,
 		},
 		&cli.BoolFlag{
 			Name:        "verbose",
 			Usage:       "Enable verbose output",
-			Destination: &config.Verbose,
+			Destination: &cfg.Verbose,
 		},
 		&cli.BoolFlag{
 			Name:        "debug",
 			Aliases:     []string{"d"},
 			Usage:       "Enable debug-level logging",
-			Destination: &config.Debug,
+			Destination: &cfg.Debug,
 			EnvVars:     []string{"DEBUG"},
 		},
 	}
@@ -151,6 +150,13 @@ Examples:
 		status.NewCommand(log),
 		update.NewCommand(log),
 	}
+
+	return c
+}
+
+func main() {
+	log := logger.NewLogger()
+	c := NewApp(log)
 
 	// Custom help template
 	c.CustomAppHelpTemplate = `NAME:

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -18,11 +18,21 @@ package main
 
 import (
 	"testing"
+
+	"github.com/NVIDIA/holodeck/internal/logger"
 )
 
-func TestVersion(t *testing.T) {
-	expected := "0.3.1"
-	if ProgramVersion != expected {
-		t.Errorf("expected version %q, got %q", expected, ProgramVersion)
+func TestNewApp(t *testing.T) {
+	log := logger.NewLogger()
+	app := NewApp(log)
+
+	if app.Version != "0.3.2" {
+		t.Errorf("expected app version %q, got %q", "0.3.2", app.Version)
+	}
+	if app.Name != "holodeck" {
+		t.Errorf("expected app name %q, got %q", "holodeck", app.Name)
+	}
+	if len(app.Commands) == 0 {
+		t.Error("expected app to have subcommands")
 	}
 }


### PR DESCRIPTION
## Summary

Bump version to v0.3.2 and update periodic cleanup workflow to use the new release.

### Changes
- Bump `ProgramVersion` to `0.3.2`
- Extract `NewApp()` constructor for testability
- Update `periodic.yaml` to use `NVIDIA/holodeck@v0.3.2`
- Add CHANGELOG entry for v0.3.2

### What's in v0.3.2
- **fix: revoke cross-referencing SG rules before deletion in cleanup (#766)** — Fixes `DependencyViolation` errors when cleaning up VPCs with mutually-referencing security groups (CP ↔ Worker pattern).
- **ci: update periodic cleanup to v0.3.1 (#765)**

### Post-merge
After merge, tag `v0.3.2` and create GitHub release. Then trigger periodic cleanup to verify the 2 stuck VPCs in us-west-1 are cleaned.