### PR TITLE
fix: treat InvalidVpcID.NotFound as success in VPC cleanup

### DIFF
--- a/pkg/cleanup/cleanup.go
+++ b/pkg/cleanup/cleanup.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -652,6 +653,12 @@ func (c *Cleaner) deleteVPC(ctx context.Context, vpcID string) error {
 		_, err := c.ec2.DeleteVpc(ctx, deleteInput)
 		if err == nil {
 			c.log.Info("Successfully deleted VPC: %s", vpcID)
+			return nil
+		}
+
+		// VPC already deleted — treat as success
+		if strings.Contains(err.Error(), "InvalidVpcID.NotFound") {
+			c.log.Info("VPC %s already deleted", vpcID)
 			return nil
 		}
 

--- a/pkg/cleanup/cleanup_ginkgo_test.go
+++ b/pkg/cleanup/cleanup_ginkgo_test.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -612,6 +613,20 @@ var _ = Describe("Cleanup Package", func() {
 				Expect(revokedIngress).To(ConsistOf("sg-cp", "sg-worker"))
 				Expect(revokedEgress).To(ConsistOf("sg-cp", "sg-worker"))
 				Expect(deletedSGs).To(ConsistOf("sg-cp", "sg-worker"))
+			})
+
+			It("should treat InvalidVpcID.NotFound as success", func() {
+				mockEC.DeleteVpcFunc = func(ctx context.Context,
+					params *ec2.DeleteVpcInput,
+					optFns ...func(*ec2.Options)) (*ec2.DeleteVpcOutput, error) {
+					return nil, fmt.Errorf("operation error EC2: DeleteVpc, https response error StatusCode: 400, api error InvalidVpcID.NotFound: The vpc ID '%s' does not exist", *params.VpcId)
+				}
+
+				cleaner, err := New(log, "us-west-2", WithEC2Client(mockEC))
+				Expect(err).NotTo(HaveOccurred())
+
+				err = cleaner.DeleteVPCResources(context.Background(), "vpc-already-gone")
+				Expect(err).NotTo(HaveOccurred())
 			})
 
 			It("should handle VPC deletion failure with retries", func() {


### PR DESCRIPTION
## Problem

The periodic cleanup action fails because the Docker action's `post-entrypoint` re-runs cleanup on VPCs that were already deleted in the main step. The `deleteVPC` function retries 3 times on `InvalidVpcID.NotFound` instead of treating it as success.

## Root Cause

`action.yml` has `post-entrypoint: 'holodeck'` which re-executes the cleanup binary in the post phase. By then, VPCs are already gone → `InvalidVpcID.NotFound` → 3 retries → failure.

## Fix

Treat `InvalidVpcID.NotFound` as success in `deleteVPC()`, matching the existing pattern in `pkg/provider/aws/delete.go:479`. If the VPC doesn't exist, cleanup succeeded.

## Also Needed (IAM - manual)

The `cnt-ci` IAM user is missing `ec2:RevokeSecurityGroupIngress` and `ec2:RevokeSecurityGroupEgress` permissions. Without these, the SG cross-reference fix (#766) can only log warnings. This needs to be added to the IAM policy.

## Testing

- Added Ginkgo test `should treat InvalidVpcID.NotFound as success`
- All 84 cleanup tests pass