### PR TITLE
release: bump version to v0.3.3

### DIFF
--- a/.github/workflows/periodic.yaml
+++ b/.github/workflows/periodic.yaml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Clean up VPCs
         if: steps.identify-resources.outputs.AWS_VPC_IDS != ''
-        uses: NVIDIA/holodeck@v0.3.2
+        uses: NVIDIA/holodeck@v0.3.3
         with:
           action: cleanup
           vpc_ids: ${{ steps.identify-resources.outputs.AWS_VPC_IDS }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v0.3.3] - 2026-04-01
+
+### Bug Fixes
+
+- **fix: treat InvalidVpcID.NotFound as success in VPC cleanup (#769)** — VPCs that no longer exist are now treated as successfully cleaned up instead of retrying and failing, fixing periodic cleanup failures caused by the Docker action's post-entrypoint re-running cleanup.
+
 ## [v0.3.2] - 2026-03-31
 
 ### Bug Fixes

--- a/cmd/cli/main.go
+++ b/cmd/cli/main.go
@@ -40,7 +40,7 @@ const (
 	// ProgramName is the canonical name of this program
 	ProgramName = "holodeck"
 	// ProgramVersion is the current version of the program
-	ProgramVersion = "0.3.2"
+	ProgramVersion = "0.3.3"
 )
 
 type config struct {

--- a/cmd/cli/main_test.go
+++ b/cmd/cli/main_test.go
@@ -26,8 +26,8 @@ func TestNewApp(t *testing.T) {
 	log := logger.NewLogger()
 	app := NewApp(log)
 
-	if app.Version != "0.3.2" {
-		t.Errorf("expected app version %q, got %q", "0.3.2", app.Version)
+	if app.Version != "0.3.3" {
+		t.Errorf("expected app version %q, got %q", "0.3.3", app.Version)
 	}
 	if app.Name != "holodeck" {
 		t.Errorf("expected app name %q, got %q", "holodeck", app.Name)


### PR DESCRIPTION
Version bump to v0.3.3 and update periodic cleanup to use the new release.

### What's in v0.3.3
- **fix: treat InvalidVpcID.NotFound as success in VPC cleanup (#769)** — Fixes periodic cleanup failures caused by the Docker action's post-entrypoint re-running cleanup on already-deleted VPCs.

### Post-merge
Tag v0.3.3, create release, trigger periodic cleanup to verify.