### PR TITLE
fix containerd.io apt package install

### DIFF
--- a/pkg/provisioner/templates/containerd.go
+++ b/pkg/provisioner/templates/containerd.go
@@ -93,8 +93,8 @@ case "${HOLODECK_OS_FAMILY}" in
 
         # Install containerd with specific version if provided
         if [[ -n "{{.Version}}" ]] && [[ "{{.Version}}" != "latest" ]]; then
-            holodeck_log "INFO" "$COMPONENT" "Attempting to install containerd.io={{.Version}}-1"
-            if ! holodeck_retry 3 "$COMPONENT" pkg_install_version "containerd.io" "{{.Version}}-1"; then
+            holodeck_log "INFO" "$COMPONENT" "Attempting to install containerd.io={{.Version}}*"
+            if ! holodeck_retry 3 "$COMPONENT" pkg_install_version "containerd.io" "{{.Version}}*"; then
                 holodeck_log "WARN" "$COMPONENT" \
                     "Specific version {{.Version}} not found, installing latest"
                 holodeck_retry 3 "$COMPONENT" pkg_install containerd.io


### PR DESCRIPTION
Holodeck cannot install containerd versions beyond `v1.7.27`. This is because of a change in the versioning of the `containerd.io` apt packages. See the output below:

```
$ apt-cache policy containerd.io
containerd.io:
  Installed: 2.2.2-1~ubuntu.24.04~noble
  Candidate: 2.2.2-1~ubuntu.24.04~noble
  Version table:
 *** 2.2.2-1~ubuntu.24.04~noble 500
        500 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages
        100 /var/lib/dpkg/status
     2.2.1-1~ubuntu.24.04~noble 500
        500 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages
     2.2.0-2~ubuntu.24.04~noble 500
        500 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages
     2.1.5-1~ubuntu.24.04~noble 500
        500 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages
     1.7.29-1~ubuntu.24.04~noble 500
        500 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages
     1.7.28-2~ubuntu.24.04~noble 500
        500 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages
     1.7.28-1~ubuntu.24.04~noble 500
        500 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages
     1.7.28-0~ubuntu.24.04~noble 500
        500 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages
     1.7.27-1 500
        500 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages
     1.7.26-1 500
        500 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages
     1.7.25-1 500
        500 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages
     1.7.24-1 500
        500 https://download.docker.com/linux/ubuntu noble/stable amd64 Packages
```

As seen above - starting with containerd `v1.7.28`, the package version format has been updated. This causes the holodeck installation scripts to fail when we set the containerd version to a more recent one.