### PR TITLE
Fix bug in NVIDIA Driver install script when package version is specified

### DIFF
--- a/.github/workflows/e2e-smoke.yaml
+++ b/.github/workflows/e2e-smoke.yaml
@@ -30,7 +30,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        label: ["default && !rpm", "cluster && minimal"]
+        label: ["default && !rpm", "cluster && minimal", "nvidia-driver"]
     name: E2E Smoke (${{ matrix.label }})
 
     steps:

--- a/pkg/provisioner/templates/nv-driver.go
+++ b/pkg/provisioner/templates/nv-driver.go
@@ -238,18 +238,29 @@ if [[ "${ID}" == "amzn" ]]; then
 else
     DRIVER_PACKAGE="cuda-drivers"
     if [[ -n "$DESIRED_VERSION" ]]; then
-		DESIRED_BRANCH="${DESIRED_VERSION%%.*}"
         case "${HOLODECK_OS_FAMILY}" in
             debian)
-                DRIVER_PACKAGE="${DRIVER_PACKAGE}-${DESIRED_BRANCH}=${DESIRED_VERSION}-*"
+                DRIVER_PINNING_PACKAGE=nvidia-driver-pinning-${DESIRED_VERSION}
                 ;;
             amazon|rhel)
                 DRIVER_PACKAGE="${DRIVER_PACKAGE}-${DESIRED_VERSION}"
                 ;;
         esac
     elif [[ -n "$DESIRED_BRANCH" ]]; then
-        DRIVER_PACKAGE="${DRIVER_PACKAGE}-${DESIRED_BRANCH}"
+        case "${HOLODECK_OS_FAMILY}" in
+            debian)
+                DRIVER_PINNING_PACKAGE=nvidia-driver-pinning-${DESIRED_BRANCH}
+                ;;
+            *)
+                DRIVER_PACKAGE="${DRIVER_PACKAGE}-${DESIRED_BRANCH}"
+                ;;
+        esac
     fi
+fi
+
+if [[ -n "$DRIVER_PINNING_PACKAGE" ]]; then
+    holodeck_log "INFO" "$COMPONENT" "Installing package: ${DRIVER_PINNING_PACKAGE}"
+    holodeck_retry 3 "$COMPONENT" install_packages_with_retry "$DRIVER_PINNING_PACKAGE"
 fi
 
 holodeck_log "INFO" "$COMPONENT" "Installing package: ${DRIVER_PACKAGE}"

--- a/pkg/provisioner/templates/nv-driver.go
+++ b/pkg/provisioner/templates/nv-driver.go
@@ -238,9 +238,10 @@ if [[ "${ID}" == "amzn" ]]; then
 else
     DRIVER_PACKAGE="cuda-drivers"
     if [[ -n "$DESIRED_VERSION" ]]; then
+		DESIRED_BRANCH="${DESIRED_VERSION%%.*}"
         case "${HOLODECK_OS_FAMILY}" in
             debian)
-                DRIVER_PACKAGE="${DRIVER_PACKAGE}=${DESIRED_VERSION}"
+                DRIVER_PACKAGE="${DRIVER_PACKAGE}-${DESIRED_BRANCH}=${DESIRED_VERSION}-*"
                 ;;
             amazon|rhel)
                 DRIVER_PACKAGE="${DRIVER_PACKAGE}-${DESIRED_VERSION}"

--- a/pkg/provisioner/templates/nv-driver_test.go
+++ b/pkg/provisioner/templates/nv-driver_test.go
@@ -243,7 +243,7 @@ func TestNvDriver_Execute_PackageWithVersion(t *testing.T) {
 	out := buf.String()
 
 	assert.Contains(t, out, `DESIRED_VERSION="560.35.03"`)
-	assert.Contains(t, out, `DRIVER_PACKAGE="${DRIVER_PACKAGE}-${DESIRED_BRANCH}=${DESIRED_VERSION}-*"`)
+	assert.Contains(t, out, `DRIVER_PINNING_PACKAGE=nvidia-driver-pinning-${DESIRED_VERSION}`)
 }
 
 func TestNvDriver_Execute_PackageWithBranch(t *testing.T) {

--- a/pkg/provisioner/templates/nv-driver_test.go
+++ b/pkg/provisioner/templates/nv-driver_test.go
@@ -243,7 +243,7 @@ func TestNvDriver_Execute_PackageWithVersion(t *testing.T) {
 	out := buf.String()
 
 	assert.Contains(t, out, `DESIRED_VERSION="560.35.03"`)
-	assert.Contains(t, out, `DRIVER_PACKAGE="${DRIVER_PACKAGE}=${DESIRED_VERSION}"`)
+	assert.Contains(t, out, `DRIVER_PACKAGE="${DRIVER_PACKAGE}-${DESIRED_BRANCH}=${DESIRED_VERSION}-*"`)
 }
 
 func TestNvDriver_Execute_PackageWithBranch(t *testing.T) {

--- a/tests/aws_test.go
+++ b/tests/aws_test.go
@@ -200,6 +200,11 @@ var _ = DescribeTable("AWS Environment E2E",
 		filePath:    filepath.Join(packagePath, "data", "test_aws_kernel.yml"),
 		description: "Tests AWS environment with kernel features enabled",
 	}, Label("kernel")),
+	Entry("Install specific version of NVIDIA Driver package", testConfig{
+		name:        "NVIDIA Driver Package Version Test",
+		filePath:    filepath.Join(packagePath, "data", "test_aws_driver_package.yml"),
+		description: "Install specific version of NVIDIA Driver package",
+	}, Label("nvidia-driver")),
 	Entry("CTK Git Source Test", testConfig{
 		name:        "CTK Git Source Test",
 		filePath:    filepath.Join(packagePath, "data", "test_aws_ctk_git.yml"),

--- a/tests/data/test_aws_driver_package.yml
+++ b/tests/data/test_aws_driver_package.yml
@@ -1,0 +1,28 @@
+apiVersion: holodeck.nvidia.com/v1alpha1
+kind: Environment
+metadata:
+  name: holodeck-aws-e2e-test
+  description: "end-to-end test infrastructure with specific NVIDIA driver package"
+spec:
+  provider: aws
+  auth:
+    keyName: cnt-ci
+    privateKey: /home/runner/.cache/key
+  instance:
+    type: g4dn.xlarge
+    region: us-west-1
+    image:
+      architecture: amd64
+  containerRuntime:
+    install: true
+    name: docker
+  nvidiaContainerToolkit:
+    install: true
+  nvidiaDriver:
+    install: true
+    source: package
+    package:
+      version: 580.105.08
+  kubernetes:
+    install: true
+    installer: kubeadm


### PR DESCRIPTION
Before this change, when nvidiaDriver.package.version was specified,
holodeck was not populating the package version correctly. As a result,
the package installation failed. For example, one would see error messages
like:

```
  sudo DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends cuda-drivers=580.95.05
  E: Version '580.95.05' for 'cuda-drivers' was not found
```

This commit ensures we construct the package version string correctly
by adding the '-*' suffix to the version string.

Fixes https://github.com/NVIDIA/holodeck/issues/783