### PR TITLE
fix(nv-driver): strict post-install version check for pinned driver installs

### DIFF
--- a/pkg/provisioner/templates/nv-driver.go
+++ b/pkg/provisioner/templates/nv-driver.go
@@ -302,6 +302,16 @@ fi
 
 FINAL_VERSION=$(nvidia-smi --query-gpu=driver_version --format=csv,noheader | head -1)
 
+# Strict version-pin check: when the user pinned a specific driver version,
+# fail loudly if the installed version does not match. Catches silent-pin
+# regressions where the package resolver picks a different point release than
+# requested (see issue #783).
+if [[ -n "$DESIRED_VERSION" ]] && [[ "$FINAL_VERSION" != "$DESIRED_VERSION" ]]; then
+    holodeck_error 11 "$COMPONENT" \
+        "Driver version mismatch: desired=${DESIRED_VERSION} installed=${FINAL_VERSION}" \
+        "Verify that version ${DESIRED_VERSION} is available in the configured CUDA repo, or pin to an available version"
+fi
+
 # Write provenance
 sudo mkdir -p /etc/nvidia-driver
 printf '%s\n' '{

--- a/pkg/provisioner/templates/nv-driver_test.go
+++ b/pkg/provisioner/templates/nv-driver_test.go
@@ -262,6 +262,31 @@ func TestNvDriver_Execute_PackageWithBranch(t *testing.T) {
 	assert.Contains(t, out, `DRIVER_PACKAGE="${DRIVER_PACKAGE}-${DESIRED_BRANCH}"`)
 }
 
+// TestNvDriver_Execute_PackageStrictVersionCheck asserts that the generated
+// script contains a runtime guard that fails loudly when the installed driver
+// version does not match the pinned DESIRED_VERSION. Without this guard a
+// silent mismatch (e.g., apt resolving to a different point release than
+// requested) would pass provisioning — the exact failure mode that motivated
+// issue #783. The template is static, so the snippet is always emitted; it
+// self-gates at runtime on DESIRED_VERSION being non-empty.
+func TestNvDriver_Execute_PackageStrictVersionCheck(t *testing.T) {
+	nvd := &NvDriver{
+		Source:  "package",
+		Version: "580.95.05",
+	}
+
+	var buf bytes.Buffer
+	require.NoError(t, nvd.Execute(&buf, v1alpha1.Environment{}))
+	out := buf.String()
+
+	assert.Contains(t, out, `[[ -n "$DESIRED_VERSION" ]] && [[ "$FINAL_VERSION" != "$DESIRED_VERSION" ]]`,
+		"guard must gate on DESIRED_VERSION being set AND check FINAL_VERSION equals it")
+	assert.Contains(t, out, `holodeck_error 11`,
+		"mismatch must abort with holodeck_error 11")
+	assert.Contains(t, out, "Driver version mismatch",
+		"error message must identify the mismatch")
+}
+
 func TestNvDriver_Execute_RunfileSource(t *testing.T) {
 	nvd := &NvDriver{
 		Source:          "runfile",


### PR DESCRIPTION
## Problem

PR #782 added version-pinning for the debian driver install path, but two small correctness gaps remain:

1. **No strict post-install assertion.** If the package resolver silently picks a different point release than requested, `nvidia-smi` reports a version the user never asked for and provisioning passes green. There was no defensive check to fail loudly.
2. **Yum-family pinning was an open question.** PR #782 only touched the debian branch. It was unclear whether the `nvidia-driver-pinning-*` approach could or should be ported to `amazon|rhel`.

## Changes

### Strict post-install version check (`pkg/provisioner/templates/nv-driver.go`)

After `FINAL_VERSION=$(nvidia-smi ...)`, when `DESIRED_VERSION` is non-empty, compare against `FINAL_VERSION` and abort via `holodeck_error 11` on mismatch.

- Only fires when the user explicitly pinned a version — unpinned installs are unaffected.
- Applies to **all** OS families (debian, amazon, rhel), so RHEL/AL2023 users get the same safety net Chris added for debian.
- Uses the existing `holodeck_error` pipeline; error code `11` is the next unused code in the template.
- The existing `test_aws_driver_package.yml` e2e fixture becomes the integration canary automatically — no new fixture needed.

## Investigation findings — yum-family pinning

Before writing code for `amazon|rhel`, I checked the CUDA repo listings for a yum-equivalent of `nvidia-driver-pinning-*`:

- **`developer.download.nvidia.com/compute/cuda/repos/ubuntu2404/x86_64/`** — `nvidia-driver-pinning-<VERSION>` metapackages exist (e.g., `nvidia-driver-pinning-580.95.05_...all.deb`). Confirms PR #782's approach.
- **`developer.download.nvidia.com/compute/cuda/repos/rhel9/x86_64/`** — **no** `nvidia-driver-pinning-*` packages exist. The yum pinning mechanism is different: versioned `cuda-drivers-<VERSION>-1.el9.x86_64.rpm` packages (e.g., `cuda-drivers-580.95.05-1.el9.x86_64.rpm`) — the version is baked into the package name itself.

**Conclusion: no code change is needed for yum-family pinning.** The existing `amazon|rhel` branch at `nv-driver.go:246` already does `DRIVER_PACKAGE="cuda-drivers-${DESIRED_VERSION}"`, which resolves exactly to the versioned RPM confirmed in the repo listing. The debian bug Chris fixed didn't exist on yum because yum pins via package name rather than a separate metapackage.

The strict check above covers yum-family users if any silent-mismatch surface does exist.

## Testing

- `go test ./pkg/provisioner/templates/...` — new `TestNvDriver_Execute_PackageStrictVersionCheck` asserts the emitted script contains the `DESIRED_VERSION`/`FINAL_VERSION` guard, the `holodeck_error 11` call, and the mismatch message. Passing.
- `go build ./...` and `go vet ./...` clean.
- Integration: the existing `tests/data/test_aws_driver_package.yml` smoke test transitively exercises the new strict check.

## Not in this PR

- No new amazon/rhel e2e fixture (doubles GPU burn; revisit once the debian smoke label stabilizes).
- Runfile/git driver source paths — different bug surface, separate follow-up.
- `NVIDIADriver.Branch` / `Version` top-level deprecation cleanup — separate API concern.

## Related

- Design doc: `docs/plans/2026-04-22-driver-pinning-followups-design.md`
- Builds on #782 (merged 2026-04-22), which closed #783.
