### PR TITLE
update default driver branch to 580

### DIFF
--- a/docs/guides/driver-sources.md
+++ b/docs/guides/driver-sources.md
@@ -23,10 +23,10 @@ spec:
 
 **Configuration options:**
 
-| Field | Description | Default |
-|-------|-------------|---------|
-| `branch` | Driver branch to install (e.g., `560`, `550`) | `575` |
-| `version` | Exact package version to install | Latest in branch |
+| Field | Description                                  | Default          |
+|-------|----------------------------------------------|------------------|
+| `branch` | Driver branch to install (e.g. `535`, `580`) | `580`            |
+| `version` | Exact package version to install             | Latest in branch |
 
 When `version` is specified, it takes precedence over `branch` for package
 selection.

--- a/pkg/provisioner/templates/nv-driver.go
+++ b/pkg/provisioner/templates/nv-driver.go
@@ -24,7 +24,7 @@ import (
 	"github.com/NVIDIA/holodeck/api/holodeck/v1alpha1"
 )
 
-const defaultNVBranch = "575"
+const defaultNVBranch = "580"
 
 // nvDriverPackageTemplate installs the NVIDIA driver from CUDA repository packages.
 // From https://docs.nvidia.com/datacenter/tesla/tesla-installation-notes/index.html#ubuntu-lts


### PR DESCRIPTION
The 575 driver branch was a new feature branch which has a limited support cycle (only 1 driver version from this branch). R580 may be a better default as it an LTS branch with a 3-year support period. It does not go into EOL until August 2028.