### PR TITLE
update default versions of k8s components

### DIFF
--- a/pkg/provisioner/templates/kubernetes.go
+++ b/pkg/provisioner/templates/kubernetes.go
@@ -1711,11 +1711,11 @@ var (
 
 // Default Versions
 const (
-	defaultKubernetesVersion     = "v1.33.3"
+	defaultKubernetesVersion     = "v1.35.3"
 	defaultKubeletReleaseVersion = "v0.18.0"
-	defaultCNIPluginsVersion     = "v1.7.1"
-	defaultCRIVersion            = "v1.33.0"
-	defaultCalicoVersion         = "v3.30.2"
+	defaultCNIPluginsVersion     = "v1.9.1"
+	defaultCRIVersion            = "v1.35.0"
+	defaultCalicoVersion         = "v3.31.5"
 )
 
 // Kubernetes holds configuration for Kubernetes installation templates.


### PR DESCRIPTION
- https://kubernetes.io/releases/#release-v1-35
- https://github.com/projectcalico/calico/releases/tag/v3.31.5
- https://github.com/kubernetes-sigs/cri-tools/releases/tag/v1.35.0
- https://github.com/containernetworking/plugins/releases/tag/v1.9.1

