### PR TITLE
chore: adopt DGXC OSS issue-management policy

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,149 +1,56 @@
-name: 🐛 Bug Report
-description: Report a bug or unexpected behavior in Holodeck
+name: "Bug report"
+description: "Report a defect (DGXC OSS policy: kind/bug)."
 title: "[Bug]: "
-labels: ["kind/bug", "needs-triage"]
+labels: ["kind/bug", "needs-triage", "priority/unprioritized"]
 body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to report a bug! Please fill out the form below.
-        
-        Before submitting, please search existing issues to avoid duplicates.
-
-  - type: textarea
-    id: description
+        Thanks for filing a bug. Please complete every section. Issues missing reproduction or version data may be re-labeled `needs-triage` and parked.
+  - type: input
+    id: version
     attributes:
-      label: Bug Description
-      description: A clear and concise description of the bug.
-      placeholder: Describe what happened...
-    validations:
-      required: true
-
+      label: Component / version
+      description: e.g. holodeck v0.4.2 / k8s-test-infra commit abc1234
+    validations: { required: true }
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: Actual behaviour, including full error output / stack traces.
+      render: shell
+    validations: { required: true }
   - type: textarea
     id: expected
     attributes:
-      label: Expected Behavior
-      description: What did you expect to happen?
-      placeholder: I expected...
-    validations:
-      required: true
-
+      label: Expected behaviour
+    validations: { required: true }
   - type: textarea
-    id: actual
+    id: repro
     attributes:
-      label: Actual Behavior
-      description: What actually happened?
-      placeholder: Instead, what happened was...
-    validations:
-      required: true
-
+      label: Steps to reproduce
+      description: Minimal, deterministic. Include manifests, commands, env.
+      render: bash
+    validations: { required: true }
   - type: textarea
-    id: reproduce
+    id: env
     attributes:
-      label: Steps to Reproduce
-      description: Steps to reproduce the behavior.
-      placeholder: |
-        1. Run `holodeck create -f ...`
-        2. Wait for provisioning...
-        3. See error
-    validations:
-      required: true
-
-  - type: dropdown
-    id: provider
-    attributes:
-      label: Cloud Provider
-      description: Which provider are you using?
-      options:
-        - AWS
-        - SSH (existing instance)
-        - Not applicable
-    validations:
-      required: true
-
-  - type: dropdown
-    id: command
-    attributes:
-      label: Holodeck Command
-      description: Which command exhibited the issue?
-      options:
-        - create
-        - delete
-        - status
-        - list
-        - dryrun
-        - GitHub Action
-        - Other
-    validations:
-      required: true
-
-  - type: textarea
-    id: environment-yaml
-    attributes:
-      label: Environment YAML
-      description: |
-        If applicable, share your environment YAML configuration.
-        Redact any sensitive information (keys, credentials, etc.).
-      placeholder: |
-        apiVersion: holodeck.nvidia.com/v1alpha1
-        kind: Environment
-        metadata:
-          name: my-environment
-        spec:
-          provider: aws
-          ...
+      label: Environment
+      description: OS, kernel, container runtime, k8s version, GPU/driver, hardware.
       render: yaml
-
+    validations: { required: true }
   - type: textarea
     id: logs
     attributes:
-      label: Relevant Logs
-      description: |
-        Include any relevant logs or error messages.
-        Please wrap in code blocks.
-      placeholder: |
-        ```
-        Error: failed to create instance: ...
-        ```
+      label: Logs / artefacts
+      description: Attach or paste relevant logs (redact secrets).
       render: shell
-
-  - type: input
-    id: holodeck-version
-    attributes:
-      label: Holodeck Version
-      description: Output of `holodeck --version` or commit SHA
-      placeholder: v1.0.0 or abc1234
-    validations:
-      required: true
-
-  - type: input
-    id: go-version
-    attributes:
-      label: Go Version
-      description: Output of `go version`
-      placeholder: go1.21.0
-
-  - type: input
-    id: os
-    attributes:
-      label: Operating System
-      description: OS and version where holodeck is running
-      placeholder: Ubuntu 22.04, macOS 14.0, etc.
-
-  - type: textarea
-    id: additional
-    attributes:
-      label: Additional Context
-      description: |
-        Add any other context about the problem here.
-        Screenshots, links, or any additional information.
-
   - type: checkboxes
-    id: checklist
+    id: terms
     attributes:
-      label: Checklist
+      label: Pre-submission checks
       options:
-        - label: I have searched existing issues for duplicates
+        - label: I searched existing issues and Discussions and this is not a duplicate.
           required: true
-        - label: I have redacted any sensitive information from logs/configs
+        - label: This is a defect, not a usage question (questions belong in Discussions).
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,13 @@
+# DGXC OSS Policy: only the four official entry points are exposed.
+# Questions are routed to GitHub Discussions per policy guidance.
 blank_issues_enabled: false
 contact_links:
-  - name: 📖 Documentation
-    url: https://github.com/NVIDIA/holodeck/tree/main/docs
-    about: Check the documentation before opening an issue
-  - name: 💬 Discussions
+  - name: Question / Help / Usage
     url: https://github.com/NVIDIA/holodeck/discussions
-    about: Ask questions or discuss features in GitHub Discussions
-  - name: 🔒 Security Vulnerabilities
-    url: https://github.com/NVIDIA/holodeck/security/advisories/new
-    about: Report security vulnerabilities privately via Security Advisories
+    about: Please use Discussions for usage questions; the issue tracker is for tracked work only.
+  - name: DGXC OSS Working Group (Slack, internal)
+    url: https://nvidia.enterprise.slack.com/archives/C0APQLRC6KD
+    about: Internal-only channel for OSS policy / process questions.
+  - name: Security vulnerability disclosure
+    url: ../blob/main/SECURITY.md
+    about: Do NOT open a public issue for vulnerabilities — see SECURITY.md.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,20 @@
+name: "Documentation request or correction"
+description: "Missing, outdated, or incorrect docs (DGXC OSS policy: kind/documentation)."
+title: "[Docs]: "
+labels: ["kind/documentation", "needs-triage", "priority/unprioritized"]
+body:
+  - type: input
+    id: location
+    attributes:
+      label: Location
+      description: URL, file path, or section affected.
+    validations: { required: true }
+  - type: textarea
+    id: issue
+    attributes:
+      label: What is wrong / missing
+    validations: { required: true }
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested correction (optional)

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,135 +1,36 @@
-name: ✨ Feature Request
-description: Suggest a new feature or enhancement for Holodeck
+name: "Feature request"
+description: "Propose a new capability or enhancement (DGXC OSS policy: kind/feature)."
 title: "[Feature]: "
-labels: ["kind/feature", "needs-triage"]
+labels: ["kind/feature", "needs-triage", "priority/unprioritized"]
 body:
-  - type: markdown
-    attributes:
-      value: |
-        Thanks for suggesting a feature! Help us understand your use case.
-        
-        Before submitting, please search existing issues to avoid duplicates.
-
-  - type: textarea
-    id: summary
-    attributes:
-      label: Feature Summary
-      description: A clear and concise description of the feature you're proposing.
-      placeholder: I would like Holodeck to...
-    validations:
-      required: true
-
   - type: textarea
     id: problem
     attributes:
-      label: Problem Statement
-      description: |
-        What problem does this feature solve? 
-        Is this related to a frustration with Holodeck?
-      placeholder: |
-        Currently, I have to manually... which is time-consuming because...
-    validations:
-      required: true
-
+      label: Problem statement
+      description: What user/operator problem does this solve? Cite the use case.
+    validations: { required: true }
   - type: textarea
-    id: solution
+    id: proposal
     attributes:
-      label: Proposed Solution
-      description: Describe your preferred solution or approach.
-      placeholder: |
-        Add a new flag `--auto-cleanup` that automatically...
-    validations:
-      required: true
-
+      label: Proposed solution
+      description: API, UX, configuration, behavioural change. Include alternatives considered.
+    validations: { required: true }
   - type: textarea
-    id: alternatives
+    id: scope
     attributes:
-      label: Alternatives Considered
-      description: |
-        Have you considered any alternative solutions or workarounds?
-      placeholder: |
-        I considered using X, but it doesn't work because...
-
+      label: Scope / non-goals
   - type: dropdown
-    id: area
+    id: tier
     attributes:
-      label: Affected Area
-      description: Which part of Holodeck would this feature affect?
-      multiple: true
-      options:
-        - CLI Commands
-        - AWS Provider
-        - SSH Provider
-        - Environment API
-        - NVIDIA Driver Installation
-        - Container Runtime (docker/containerd/crio)
-        - Kubernetes Installation
-        - NVIDIA Container Toolkit
-        - GitHub Action
-        - Documentation
-        - Other
-    validations:
-      required: true
-
-  - type: dropdown
-    id: priority
-    attributes:
-      label: Suggested Priority
-      description: How important is this feature to your workflow?
-      options:
-        - P0 - Blocker (cannot use Holodeck without this)
-        - P1 - High (significant impact on workflow)
-        - P2 - Medium (nice to have, would improve experience)
-        - P3 - Low (minor improvement)
-    validations:
-      required: true
-
-  - type: textarea
-    id: examples
-    attributes:
-      label: Example Usage
-      description: |
-        If applicable, show how you'd expect to use this feature.
-        Include example commands, YAML configurations, or code.
-      placeholder: |
-        ```bash
-        holodeck create -f env.yaml --auto-cleanup
-        ```
-        
-        Or in YAML:
-        ```yaml
-        spec:
-          autoCleanup:
-            enabled: true
-            ttl: 24h
-        ```
-      render: markdown
-
-  - type: textarea
-    id: acceptance
-    attributes:
-      label: Acceptance Criteria
-      description: |
-        What would need to be true for this feature to be considered complete?
-      placeholder: |
-        - [ ] New flag `--auto-cleanup` added to create command
-        - [ ] Documentation updated
-        - [ ] Unit tests added
-        - [ ] E2E test covering the feature
-
-  - type: textarea
-    id: additional
-    attributes:
-      label: Additional Context
-      description: |
-        Add any other context, screenshots, or references here.
-        Links to similar features in other tools are helpful.
-
+      label: Audience
+      options: ["Operators / cluster admins", "End users", "Internal NVIDIA teams", "Other"]
+    validations: { required: true }
   - type: checkboxes
-    id: contribution
+    id: terms
     attributes:
-      label: Contribution
+      label: Pre-submission checks
       options:
-        - label: I would be willing to contribute this feature
-        - label: I have searched existing issues for duplicates
+        - label: I searched existing issues / Discussions and this is not a duplicate.
+          required: true
+        - label: I understand triage cadence is weekly and Unprioritized SLA is 7 calendric days.
           required: true

--- a/.github/workflows/stale.yaml
+++ b/.github/workflows/stale.yaml
@@ -1,25 +1,54 @@
-name: Stale issues
+# DGXC OSS stale lifecycle — mirrors the policy:
+#   - 90 days inactive  -> label `lifecycle/stale`
+#   - +30 days inactive -> close
+#   - exempt: label `lifecycle/frozen`
+# Reference: https://github.com/NVIDIA/gpu-operator/blob/main/.github/workflows/stale.yaml
+name: "Mark and close stale issues"
 
 on:
-  workflow_dispatch:
   schedule:
-    - cron: "21 4 * * *"
+    - cron: "30 1 * * *"   # daily 01:30 UTC
+  workflow_dispatch:
+
+permissions:
+  issues: write
+  pull-requests: write
 
 jobs:
   stale:
-    permissions:
-      actions: write
-      issues: write
     runs-on: ubuntu-latest
-
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue is stale because it has been open 90 days with no activity. This issue will be closed in 30 days unless new comments are made or the stale label is removed. To skip these checks, apply the "feature, enhancement or lifecycle/frozen" labels.'
-          stale-issue-label: 'lifecycle/stale'
-          exempt-issue-labels: 'lifecycle/frozen,feature,enhancement'
-          days-before-stale: 90
-          close-issue-message: 'This issue was automatically closed due to inactivity.'
+          # --- thresholds (policy) ---
+          days-before-issue-stale: 90
           days-before-issue-close: 30
+          days-before-pr-stale: 90
+          days-before-pr-close: 30
+
+          # --- labels ---
+          stale-issue-label: "lifecycle/stale"
+          stale-pr-label: "lifecycle/stale"
+          exempt-issue-labels: "lifecycle/frozen"
+          exempt-pr-labels: "lifecycle/frozen"
+
+          # --- messages ---
+          stale-issue-message: |
+            This issue has had no activity for 90 days and is being marked `lifecycle/stale`
+            per the DGXC OSS Issue Mgmt policy. It will be auto-closed in 30 days unless:
+              * a maintainer adds the `lifecycle/frozen` label, or
+              * a comment / commit reactivates it.
+          close-issue-message: |
+            Closing per DGXC OSS stale policy (no activity for 120 days). Re-open with new
+            evidence if still relevant.
+          stale-pr-message: |
+            This PR has had no activity for 90 days and is being marked `lifecycle/stale`.
+            It will be auto-closed in 30 days unless updated or labeled `lifecycle/frozen`.
+          close-pr-message: |
+            Closing per DGXC OSS stale policy (no activity for 120 days).
+
+          # --- behaviour ---
           remove-stale-when-updated: true
-          operations-per-run: 300
+          operations-per-run: 200
+          ascending: true
+          delete-branch: false


### PR DESCRIPTION
Adopts the DGXC OSS GitHub Issue Mgmt policy: issue templates restricted to the four official kinds, stale lifecycle automation matching the gpu-operator pattern, and Discussions routing for questions.