### PR TITLE
Add Ubuntu26.04 support

### DIFF
--- a/docs/guides/os-selection.md
+++ b/docs/guides/os-selection.md
@@ -27,6 +27,7 @@ Run `holodeck os list` to see all available operating systems:
 
 | OS ID | Family | SSH User | Package Manager | Architectures |
 |-------|--------|----------|-----------------|---------------|
+| ubuntu-26.04 | debian | ubuntu | apt | x86_64, arm64 |
 | ubuntu-24.04 | debian | ubuntu | apt | x86_64, arm64 |
 | ubuntu-22.04 | debian | ubuntu | apt | x86_64, arm64 |
 | ubuntu-20.04 | debian | ubuntu | apt | x86_64, arm64 |
@@ -90,6 +91,7 @@ rocky-9              rhel      rocky       dnf          x86_64, arm64
 ubuntu-20.04         debian    ubuntu      apt          x86_64, arm64
 ubuntu-22.04         debian    ubuntu      apt          x86_64, arm64
 ubuntu-24.04         debian    ubuntu      apt          x86_64, arm64
+ubuntu-26.04         debian    ubuntu      apt          x86_64, arm64
 ```
 
 ### Get OS Details

--- a/examples/aws_simple_os.yaml
+++ b/examples/aws_simple_os.yaml
@@ -5,6 +5,7 @@
 # based on the region and architecture.
 #
 # Supported OS values (run 'holodeck os list' for current list):
+#   - ubuntu-26.04  : Ubuntu 26.04 LTS (Resolute Raccoon)
 #   - ubuntu-24.04  : Ubuntu 24.04 LTS (Noble Numbat)
 #   - ubuntu-22.04  : Ubuntu 22.04 LTS (Jammy Jellyfish)
 #   - ubuntu-20.04  : Ubuntu 20.04 LTS (Focal Fossa)

--- a/internal/ami/registry.go
+++ b/internal/ami/registry.go
@@ -22,6 +22,20 @@ import (
 
 // registry contains the mapping of OS identifiers to their metadata.
 var registry = map[string]OSImage{
+	"ubuntu-26.04": {
+		ID:              "ubuntu-26.04",
+		Name:            "Ubuntu 26.04 LTS (Resolute Raccoon)",
+		Family:          OSFamilyDebian,
+		SSHUsername:     "ubuntu",
+		PackageManager:  PackageManagerAPT,
+		MinRootVolumeGB: 20,
+		OwnerID:         "099720109477",
+		NamePattern:     "ubuntu/images/hvm-ssd-gp3/ubuntu-resolute-26.04-%s-server-*",
+		SSMPath: "/aws/service/canonical/ubuntu/server/26.04/stable/" +
+			"current/%s/hvm/ebs-gp3/ami-id",
+		NameArchMap:   map[string]string{"x86_64": "amd64"},
+		Architectures: []string{"x86_64", "arm64"},
+	},
 	"ubuntu-24.04": {
 		ID:              "ubuntu-24.04",
 		Name:            "Ubuntu 24.04 LTS (Noble Numbat)",

--- a/internal/ami/resolver_test.go
+++ b/internal/ami/resolver_test.go
@@ -84,6 +84,12 @@ func TestRegistry_Get(t *testing.T) {
 		wantUser string
 	}{
 		{
+			name:     "ubuntu-26.04 exists",
+			osID:     "ubuntu-26.04",
+			wantOK:   true,
+			wantUser: "ubuntu",
+		},
+		{
 			name:     "ubuntu-24.04 exists",
 			osID:     "ubuntu-24.04",
 			wantOK:   true,
@@ -141,6 +147,7 @@ func TestRegistry_Get(t *testing.T) {
 func TestRegistry_List(t *testing.T) {
 	ids := List()
 	assert.NotEmpty(t, ids)
+	assert.Contains(t, ids, "ubuntu-26.04")
 	assert.Contains(t, ids, "ubuntu-24.04")
 	assert.Contains(t, ids, "ubuntu-22.04")
 	assert.Contains(t, ids, "ubuntu-20.04")
@@ -166,6 +173,7 @@ func TestRegistry_All(t *testing.T) {
 }
 
 func TestRegistry_Exists(t *testing.T) {
+	assert.True(t, Exists("ubuntu-26.04"))
 	assert.True(t, Exists("ubuntu-22.04"))
 	assert.True(t, Exists("amazon-linux-2023"))
 	assert.False(t, Exists("unknown-os"))


### PR DESCRIPTION
## Description

Ubuntu26.04 support added for holodeck aws instance


## Motivation

The changes to the gpu-driver-container for ubuntu26.04 need to be tested end-to-end on an ubuntu260.04 AWS instance.

## Type of Change

<!-- Mark the relevant option with an [x] -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to change)
- [x] 📝 Documentation update
- [ ] 🔧 Refactoring (no functional changes)
- [ ] 🧪 Test improvements
- [ ] 🔨 Build/CI changes

## Changes Made

file: 
- docs/guides/os-selection.md 
- examples/aws_simple_os.yaml 
- internal/ami/registry.go
- internal/ami/resolver_test.go

## Testing

<!-- Describe the testing performed -->

- [x] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Manual testing performed

### Test Commands Run

```bash
# Commands used to test the changes
make test
make lint
```

## Checklist

- [x] My code follows the project's coding conventions
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] I have updated the documentation (if applicable)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix/feature works
- [x] New and existing tests pass locally
- [x] I have signed off my commits (`git commit -s`)


