### PR TITLE
fix(provisioner): expose CRI-O bundled runtimes on PATH for AL2023

### DIFF
--- a/pkg/provisioner/templates/crio.go
+++ b/pkg/provisioner/templates/crio.go
@@ -151,6 +151,20 @@ POLICY
 unqualified-search-registries = ["docker.io"]
 REGISTRIES
         fi
+        # Expose the opensuse CRI-O package's bundled runtimes on PATH.
+        # Without this, 'nvidia-ctk runtime configure --runtime=crio' (run
+        # later by the container-toolkit step) logs
+        #   "Could not infer options from runtimes [runc crun]"
+        # and writes /etc/crio/crio.conf.d/99-nvidia.toml that omits the
+        # runc/crun runtime tables, leaving crio with no usable runtime on
+        # restart. See: nvidia-container-toolkit 1.19.1+ behavior change.
+        for bin in runc crun conmon pinns; do
+            src="/usr/libexec/crio/${bin}"
+            dst="/usr/bin/${bin}"
+            if [[ -x "${src}" && ! -e "${dst}" ]]; then
+                sudo ln -s "${src}" "${dst}"
+            fi
+        done
         ;;
     rhel)
         holodeck_retry 3 "$COMPONENT" pkg_install cri-o crun containers-common

--- a/pkg/provisioner/templates/crio_test.go
+++ b/pkg/provisioner/templates/crio_test.go
@@ -177,6 +177,17 @@ func TestCriO_Execute_PackageTemplate_OSFamilyBranching(t *testing.T) {
 		"Amazon Linux must create policy.json for CRI-O")
 	assert.Contains(t, out, "/etc/containers/registries.conf",
 		"Amazon Linux must create registries.conf")
+	// AL2023 must expose bundled runtimes on PATH so nvidia-ctk runtime
+	// configure can infer existing runc/crun entries and preserve them in
+	// /etc/crio/crio.conf.d/99-nvidia.toml. Without this, nvidia-ctk logs
+	// "Could not infer options from runtimes [runc crun]" and writes a
+	// drop-in that omits the runtimes, leaving crio with no usable runtime.
+	assert.Contains(t, out, "/usr/libexec/crio/",
+		"Amazon Linux must reference bundled runtimes under /usr/libexec/crio/")
+	assert.Regexp(t, `for bin in runc crun( |\b)`, out,
+		"Amazon Linux must iterate at least runc and crun when exposing bundled runtimes")
+	assert.Contains(t, out, "ln -s",
+		"Amazon Linux must symlink bundled runtimes onto PATH")
 
 	// RHEL uses crun + containers-common
 	assert.Contains(t, out, "pkg_install cri-o crun containers-common",


### PR DESCRIPTION
## Problem

The `rpm-al2023` E2E job has been failing on every merge to `main` since 2026-05-25 12:15Z (4 consecutive CI runs, all on different commits, the first of which is the docs-only #819 — proof this is not a code regression introduced by holodeck).

CI log (run [#26402728532](https://github.com/NVIDIA/holodeck/actions/runs/26402728532), job `e2e-test / E2E Test (rpm-al2023)`):

```
+ sudo nvidia-ctk runtime configure --runtime=crio --set-as-default --enable-cdi=false
time="2026-05-25T14:02:55Z" level=warning msg="Could not infer options from runtimes [runc crun]"
time="2026-05-25T14:02:55Z" level=info msg="Wrote updated config to /etc/crio/crio.conf.d/99-nvidia.toml"
time="2026-05-25T14:02:55Z" level=info msg="It is recommended that crio daemon be restarted."
+ sudo systemctl restart crio
Job for crio.service failed because the control process exited with error code.
```

## Root cause

`nvidia-container-toolkit 1.19.1` changed `nvidia-ctk runtime configure --runtime=crio` to require pre-existing `runc`/`crun` entries in crio's config in order to preserve them when writing `/etc/crio/crio.conf.d/99-nvidia.toml`. The opensuse CRI-O RPM on AL2023 bundles its OCI runtimes under `/usr/libexec/crio/` rather than installing them on `PATH`, so nvidia-ctk cannot discover them and writes a drop-in that omits the runtime tables. The subsequent `systemctl restart crio` then fails because crio has no usable runtimes.

RHEL/Fedora and Debian are unaffected because their CRI-O packages install runtimes on `PATH` to begin with.

## Fix

Symlink the bundled binaries (`runc`, `crun`, `conmon`, `pinns`) from `/usr/libexec/crio/` into `/usr/bin/` in the AL2023 branch of `pkg/provisioner/templates/crio.go`, after `cri-o` is installed but before nvidia-container-toolkit runs. The symlinks are idempotent (`[[ -x src && ! -e dst ]]`).

## Testing

- Unit: `TestCriO_Execute_PackageTemplate_OSFamilyBranching` extended to assert the AL2023 branch installs symlinks covering at least `runc` and `crun`.
- Full `go test ./pkg/... ./internal/...`: green locally.
- E2E: this PR will exercise `rpm-al2023` (and the rest of the matrix) in CI.

## Scope

Targeted, AL2023-only, 25-line diff. No behavioral change for any other OS family. Required for cutting **v0.3.4**.
