### PR TITLE
feat(release): ship macOS via Homebrew Cask to avoid Tahoe sandbox bug

### DIFF
--- a/.github/workflows/homebrew-validate.yaml
+++ b/.github/workflows/homebrew-validate.yaml
@@ -7,10 +7,12 @@ on:
   pull_request:
     paths:
       - 'Formula/**'
+      - 'Casks/**'
   push:
     branches: [main]
     paths:
       - 'Formula/**'
+      - 'Casks/**'
 
 permissions:
   contents: read
@@ -24,9 +26,21 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Audit formula
+        if: hashFiles('Formula/holodeck.rb') != ''
         run: |
           brew audit --strict --online Formula/holodeck.rb
 
-      - name: Style check
+      - name: Audit cask
+        if: hashFiles('Casks/holodeck.rb') != ''
+        run: |
+          brew audit --cask --strict --online Casks/holodeck.rb
+
+      - name: Style check (formula)
+        if: hashFiles('Formula/holodeck.rb') != ''
         run: |
           brew style Formula/holodeck.rb
+
+      - name: Style check (cask)
+        if: hashFiles('Casks/holodeck.rb') != ''
+        run: |
+          brew style Casks/holodeck.rb

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,7 +33,9 @@ jobs:
         run: |
           if [ -z "$HOMEBREW_TAP_GITHUB_TOKEN" ]; then
             echo "::error::HOMEBREW_TAP_GITHUB_TOKEN repo secret is not set."
-            echo "::error::The release would publish but the Homebrew formula PR would not open."
+            echo "::error::The release would publish but the Homebrew Cask"
+            echo "::error::(Casks/holodeck.rb) and Formula (Formula/holodeck.rb)"
+            echo "::error::bumps would not land on main."
             echo "::error::See docs/release.md (One-time setup) for PAT creation steps."
             exit 1
           fi

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,9 +1,14 @@
 # Copyright (c) 2026, NVIDIA CORPORATION.  All rights reserved.
 # Licensed under the Apache License, Version 2.0.
 #
-# GoReleaser config for cross-building holodeck binaries, publishing
-# them as GitHub Release assets, and auto-updating the Homebrew formula
-# at Formula/holodeck.rb on every v* tag.
+# GoReleaser config for cross-building holodeck binaries, publishing them as
+# GitHub Release assets, and auto-updating the Homebrew tap on every v* tag.
+#
+# Homebrew distribution split:
+#   - macOS  → Cask at Casks/holodeck.rb   (avoids brew's Formula sandbox
+#                                            PTY bug on macOS Tahoe 26.x; see
+#                                            docs/release.md)
+#   - Linux  → Formula at Formula/holodeck.rb
 #
 # See docs/release.md for the release process.
 
@@ -16,13 +21,28 @@ before:
     - go mod tidy
 
 builds:
-  - id: holodeck
+  # Split the holodeck CLI into per-OS builds so the Linux Formula and macOS
+  # Cask can each target only their platform via archive ids.
+  - id: holodeck-linux
     main: ./cmd/cli
     binary: holodeck
     env:
       - CGO_ENABLED=0
     goos:
       - linux
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -s -w
+      - -X main.ProgramVersion={{ .Version }}
+
+  - id: holodeck-darwin
+    main: ./cmd/cli
+    binary: holodeck
+    env:
+      - CGO_ENABLED=0
+    goos:
       - darwin
     goarch:
       - amd64
@@ -45,9 +65,19 @@ builds:
       - -s -w
 
 archives:
-  - id: holodeck
+  - id: holodeck-linux
     ids:
-      - holodeck
+      - holodeck-linux
+    name_template: "holodeck_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+    formats:
+      - tar.gz
+    files:
+      - LICENSE
+      - README.md
+
+  - id: holodeck-darwin
+    ids:
+      - holodeck-darwin
     name_template: "holodeck_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     formats:
       - tar.gz
@@ -87,10 +117,11 @@ release:
   draft: false
   prerelease: auto
 
+# Linux-only Homebrew Formula. macOS users install via the Cask block below.
 brews:
   - name: holodeck
     ids:
-      - holodeck
+      - holodeck-linux
     repository:
       owner: NVIDIA
       name: holodeck
@@ -109,10 +140,52 @@ brews:
       name: nvidia-ci
       email: nvidia-ci@users.noreply.github.com
     commit_msg_template: |
-      chore(brew): bump {{ .ProjectName }} to {{ .Tag }}
+      chore(brew): bump {{ .ProjectName }} formula to {{ .Tag }}
 
       Signed-off-by: nvidia-ci <nvidia-ci@users.noreply.github.com>
     install: |
       bin.install "holodeck"
     test: |
       system "#{bin}/holodeck", "--version"
+
+# macOS-only Homebrew Cask. Casks skip brew's Formula build sandbox, which
+# avoids the PTY.open failure that breaks Formula installs on macOS Tahoe
+# 26.x with brew 5.1.x + portable-ruby 4.0.x. The xattr hook strips the
+# com.apple.quarantine attribute Gatekeeper attaches to downloads of
+# unsigned binaries — until we set up Apple Developer signing/notarization,
+# this is what lets `brew install nvidia/holodeck/holodeck` run cleanly.
+homebrew_casks:
+  - name: holodeck
+    ids:
+      - holodeck-darwin
+    binaries:
+      - holodeck
+    repository:
+      owner: NVIDIA
+      name: holodeck
+      branch: main
+      pull_request:
+        enabled: true
+        draft: false
+        base:
+          branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Casks
+    homepage: "https://github.com/NVIDIA/holodeck"
+    description: "Tool for creating and managing GPU-ready cloud test environments"
+    license: "Apache-2.0"
+    commit_author:
+      name: nvidia-ci
+      email: nvidia-ci@users.noreply.github.com
+    commit_msg_template: |
+      chore(brew): bump {{ .ProjectName }} cask to {{ .Tag }}
+
+      Signed-off-by: nvidia-ci <nvidia-ci@users.noreply.github.com>
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr",
+                           args: ["-dr", "com.apple.quarantine", "#{staged_path}/holodeck"],
+                           sudo: false
+          end

--- a/README.md
+++ b/README.md
@@ -54,6 +54,23 @@ Pre-built binaries for macOS (arm64, amd64) and Linux (arm64, amd64) are
 downloaded from the [GitHub Releases page](https://github.com/NVIDIA/holodeck/releases/latest).
 Run `brew upgrade nvidia/holodeck/holodeck` to update.
 
+> **How the install works**
+>
+> Behind the scenes the tap ships two artifacts, both auto-bumped by
+> GoReleaser on every release:
+>
+> | Platform | Mechanism | File |
+> | --- | --- | --- |
+> | macOS (arm64 / amd64) | Homebrew **Cask** | `Casks/holodeck.rb` |
+> | Linux (arm64 / amd64) | Homebrew **Formula** | `Formula/holodeck.rb` |
+>
+> macOS uses a Cask because brew's Formula build-sandbox triggers a
+> `PTY.open` failure on macOS Tahoe (26.x) + brew 5.1.x + portable-ruby
+> 4.0.x. Casks skip that sandbox path, so `brew install` works cleanly.
+> Until we wire up Apple Developer code signing + notarization, the Cask's
+> `postflight` hook removes the `com.apple.quarantine` xattr so Gatekeeper
+> doesn't block the unsigned binary.
+
 ### Install from source
 
 ```bash

--- a/docs/release.md
+++ b/docs/release.md
@@ -5,9 +5,19 @@ pushing a `v*` git tag. The pipeline cross-builds the CLI (linux/darwin ×
 amd64/arm64) and the action binary (linux × amd64/arm64) with
 `CGO_ENABLED=0`, packages each binary as a tar.gz (bundling `LICENSE`
 plus the README for the CLI), computes SHA256 checksums, publishes
-everything to the GitHub Release for the tag, and opens a PR updating
-`Formula/holodeck.rb` with the new version, archive URLs, and SHA256
-sums.
+everything to the GitHub Release for the tag, and bumps **two**
+tap artifacts in lockstep:
+
+- `Casks/holodeck.rb` — Homebrew **Cask** for macOS (arm64 + amd64).
+  Casks bypass brew's Formula build-sandbox, which avoids the
+  `PTY.open` failure that breaks Formula installs on macOS Tahoe
+  (26.x) + brew 5.1.x + portable-ruby 4.0.x.
+- `Formula/holodeck.rb` — Homebrew **Formula** for Linux (arm64 +
+  amd64). The Formula carries `depends_on :linux` so brew refuses to
+  install it on macOS even if a user tries `--formula`.
+
+`brew install nvidia/holodeck/holodeck` resolves to the Cask on macOS
+and the Formula on Linux automatically.
 
 [goreleaser]: https://goreleaser.com/
 
@@ -55,9 +65,10 @@ make snapshot
 ```
 
 Inspect `dist/` — it should contain 6 archive tar.gz files plus
-`checksums.txt` plus a source tarball. The generated formula at
-`dist/homebrew/Formula/holodeck.rb` should be a syntactically valid
-Ruby class.
+`checksums.txt` plus a source tarball. Both the generated
+`dist/homebrew/Casks/holodeck.rb` (macOS-only, with the `postflight`
+`xattr` hook) and `dist/homebrew/Formula/holodeck.rb` (Linux-only,
+declares `depends_on :linux`) should be syntactically valid Ruby.
 
 ### 2. Tag and push
 
@@ -86,8 +97,13 @@ checksums.txt
 holodeck-X.Y.Z.tar.gz   (source archive, auto-attached)
 ```
 
-A new PR titled `chore(brew): bump holodeck to vX.Y.Z` should also be
-open. Review and merge it.
+Two PRs (or two direct commits, depending on whether branch protection
+forces PR mode for the `nvidia-ci` PAT) should also land on `main`:
+
+- `chore(brew): bump holodeck cask to vX.Y.Z`    — touches `Casks/holodeck.rb`
+- `chore(brew): bump holodeck formula to vX.Y.Z` — touches `Formula/holodeck.rb`
+
+Review and merge any that aren't direct commits.
 
 [release-tag]: https://github.com/NVIDIA/holodeck/releases
 
@@ -104,13 +120,17 @@ holodeck --version
 ```
 
 Install should complete in under 30 seconds (no Go toolchain build),
-and `holodeck --version` should print `holodeck version vX.Y.Z`.
+and `holodeck --version` should print `holodeck version vX.Y.Z`. On
+macOS the Cask's `postflight` hook removes the `com.apple.quarantine`
+xattr automatically — no manual `xattr -d` required.
 
-If install fails, common causes: the formula-bump PR has not been
-merged yet (users hit the previous version); the formula audit failed
-(check the `homebrew-validate` workflow on the formula-bump PR); or an
+If install fails, common causes: the cask/formula bump hasn't landed on
+main yet (users hit the previous version); the cask/formula audit
+failed (check the `homebrew-validate` workflow on the bump PR); an
 archive URL returns 404 (the release wasn't fully published — re-run
-the workflow).
+the workflow); or, if `holodeck` is killed on first launch by
+Gatekeeper, the `postflight` hook didn't run (re-install with
+`HOMEBREW_NO_INSTALL_FROM_API=1 brew reinstall` and inspect output).
 
 ### 5. Cleanup if a release goes wrong
 
@@ -132,11 +152,18 @@ Then fix the underlying issue and re-tag.
 `--skip=announce` to the snapshot command (already done in the
 Makefile), and ensure your local git has at least one tag.
 
-**Formula PR not opened:** check that `HOMEBREW_TAP_GITHUB_TOKEN` is
-set and not expired. Check the release workflow logs for the `brews`
-step output.
+**Formula/Cask bump not landing on main:** check that
+`HOMEBREW_TAP_GITHUB_TOKEN` is set and not expired. Check the release
+workflow logs for the `homebrew formula` and `homebrew cask` step
+output.
 
 **`brew install` builds from source instead of using the binary:** the
 formula isn't pointing at a valid archive URL. Inspect
-`Formula/holodeck.rb` and confirm the URL for your platform returns
-200.
+`Formula/holodeck.rb` (Linux) or `Casks/holodeck.rb` (macOS) and
+confirm the URL for your platform returns 200.
+
+**macOS install fails with `can't get Master/Slave device`:** the user
+is hitting the Tahoe brew Formula sandbox bug. Confirm they're on the
+Cask path (`brew info --cask nvidia/holodeck/holodeck` should show the
+cask). If brew picked the Formula instead, `brew uninstall holodeck &&
+brew install --cask nvidia/holodeck/holodeck` forces the Cask.


### PR DESCRIPTION
## Problem

After PR #825 shipped v0.3.5, smoke-testing the install path on macOS
Tahoe 26.3 (brew 5.1.15 + portable-ruby 4.0.5_1) failed with:

\`\`\`
==> Installing holodeck from nvidia/holodeck
Error: can't get Master/Slave device
/opt/homebrew/Library/Homebrew/sandbox.rb:337:in 'PTY.open'
/opt/homebrew/Library/Homebrew/sandbox.rb:330:in 'Sandbox#run'
/opt/homebrew/Library/Homebrew/formula_installer.rb:1151:in 'FormulaInstaller#build'
\`\`\`

The release artifact itself is correct (SHA256 verified, binary runs
when extracted manually). The failure is inside brew's own
\`Sandbox#run\` → \`PTY.open\`, the build-sandbox layer brew wraps every
non-bottled Formula install with.

**Confirmed environmental, not a holodeck-formula bug**: reproduced
with \`brew install goreleaser/tap/nfpm\` — the canonical
GoReleaser-generated reference Formula — which dies with the identical
traceback. \`goreleaser\` from the same tap installs cleanly because it
ships as a **Cask**, which bypasses the brew Formula build-sandbox
entirely.

## Fix

Split the Homebrew distribution:

| Platform | Mechanism | File |
| --- | --- | --- |
| macOS arm64+amd64 | Homebrew **Cask** | \`Casks/holodeck.rb\` |
| Linux arm64+amd64 | Homebrew **Formula** | \`Formula/holodeck.rb\` |

\`brew install nvidia/holodeck/holodeck\` resolves to the right one
automatically per platform. The Linux Formula declares
\`depends_on :linux\` so brew refuses it on macOS even if a user passes
\`--formula\`.

The single \`holodeck\` CLI build in \`.goreleaser.yaml\` is split into
\`holodeck-linux\` and \`holodeck-darwin\` GoReleaser builds with
matching archive ids — the Formula's \`ids:\` filter produces a
Linux-only Formula, the Cask's \`ids:\` filter produces a macOS-only
Cask. **Release assets are unchanged** (same six tarballs + checksums +
source archive); only the tap artifacts change shape.

The Cask carries a \`postflight\` hook that strips
\`com.apple.quarantine\` from the staged binary so Gatekeeper does not
block the unsigned holodeck binary on first launch. Stopgap until
Apple Developer code signing and notarization are wired up.

## Files

- \`.goreleaser.yaml\` — split builds, added \`homebrew_casks:\` block, narrowed \`brews:\` to Linux archive id
- \`.github/workflows/homebrew-validate.yaml\` — audit Cask in addition to Formula, gate each step on file presence
- \`.github/workflows/release.yaml\` — secret-verification error message references both artifacts
- \`README.md\` — install section explains the Cask + Formula split
- \`docs/release.md\` — runbook updated for dual-artifact layout, troubleshooting for the Tahoe sandbox case

## Testing done

- \`goreleaser check\` → valid (one accepted deprecation warning on \`brews:\` — the modern recommendation is to drop Linux brew and ship deb/rpm via \`nfpms:\`; deferred to a follow-up)
- \`make snapshot\` → six archives + source tarball + \`dist/homebrew/Casks/holodeck.rb\` (macOS only, postflight xattr hook present) + \`dist/homebrew/Formula/holodeck.rb\` (\`depends_on :linux\`)
- Manual install of v0.3.5 darwin/arm64 tarball verified the binary itself works (\`holodeck version v0.3.5\`)

## Follow-ups (separate PRs)

- File upstream brew issue with the full traceback and the \`nfpm\` repro — the sandbox-PTY failure affects every third-party tap Formula on Tahoe
- Migrate Linux from \`brews:\` to \`nfpms:\` (deb/rpm) to drop the deprecation warning and stop relying on Linux Homebrew

Closes the macOS install gap from #825.