### PR TITLE
docs(brew): split macOS Cask and Linux Formula install commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,34 +42,47 @@ A tool for creating and managing GPU-ready Cloud test environments.
 
 See [docs/quick-start.md](docs/quick-start.md) for a full walkthrough.
 
-### Install via Homebrew (macOS, Linux)
+### Install via Homebrew
 
 ```bash
 brew tap nvidia/holodeck https://github.com/NVIDIA/holodeck
-brew install nvidia/holodeck/holodeck
+```
+
+**macOS** (arm64 / amd64) — installs via Cask:
+
+```bash
+brew install --cask nvidia/holodeck/holodeck
 holodeck --help
 ```
 
-Pre-built binaries for macOS (arm64, amd64) and Linux (arm64, amd64) are
-downloaded from the [GitHub Releases page](https://github.com/NVIDIA/holodeck/releases/latest).
-Run `brew upgrade nvidia/holodeck/holodeck` to update.
+**Linux** (arm64 / amd64) — installs via Formula:
 
-> **How the install works**
->
-> Behind the scenes the tap ships two artifacts, both auto-bumped by
-> GoReleaser on every release:
+```bash
+brew install --formula nvidia/holodeck/holodeck
+holodeck --help
+```
+
+The `--cask` / `--formula` flags are required to disambiguate: the tap
+ships both an `holodeck` Cask (macOS-only) and an `holodeck` Formula
+(Linux-only, declares `depends_on :linux`), and brew defaults to the
+Formula when both exist by the same name. Pre-built binaries for both
+platforms are downloaded from the [GitHub Releases
+page](https://github.com/NVIDIA/holodeck/releases/latest). Run
+`brew upgrade --cask nvidia/holodeck/holodeck` (macOS) or
+`brew upgrade --formula nvidia/holodeck/holodeck` (Linux) to update.
+
+> **Why the platform split?** macOS uses a Cask because brew's Formula
+> build-sandbox triggers a `PTY.open` failure on macOS Tahoe (26.x) +
+> brew 5.1.x + portable-ruby 4.0.x. Casks skip that sandbox path, so
+> `brew install --cask` works cleanly. Until Apple Developer code signing
+> and notarization are wired up, the Cask's `postflight` hook removes the
+> `com.apple.quarantine` xattr so Gatekeeper doesn't block the unsigned
+> binary.
 >
 > | Platform | Mechanism | File |
 > | --- | --- | --- |
 > | macOS (arm64 / amd64) | Homebrew **Cask** | `Casks/holodeck.rb` |
 > | Linux (arm64 / amd64) | Homebrew **Formula** | `Formula/holodeck.rb` |
->
-> macOS uses a Cask because brew's Formula build-sandbox triggers a
-> `PTY.open` failure on macOS Tahoe (26.x) + brew 5.1.x + portable-ruby
-> 4.0.x. Casks skip that sandbox path, so `brew install` works cleanly.
-> Until we wire up Apple Developer code signing + notarization, the Cask's
-> `postflight` hook removes the `com.apple.quarantine` xattr so Gatekeeper
-> doesn't block the unsigned binary.
 
 ### Install from source
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -115,7 +115,10 @@ amd64 are good-to-haves but not blocking.
 
 ```bash
 brew tap nvidia/holodeck https://github.com/NVIDIA/holodeck
-brew install nvidia/holodeck/holodeck
+# macOS:
+brew install --cask nvidia/holodeck/holodeck
+# Linux:
+brew install --formula nvidia/holodeck/holodeck
 holodeck --version
 ```
 


### PR DESCRIPTION
## Problem

After #835 / v0.3.6 the tap ships both a Cask and a Formula named `holodeck`. brew's `<tap>/<name>` resolution prefers Formula over Cask when both exist with the same name. On macOS the plain command from the README:

```
brew install nvidia/holodeck/holodeck
```

resolves to the Linux Formula and dies on its `depends_on :linux` gate:

```
Warning: Treating nvidia/holodeck/holodeck as a formula.
==> Requirements
Required: Linux
holodeck: Linux is required for this software.
Error: holodeck: An unsatisfied requirement failed this build.
```

users never reach the Cask.

## Fix

Docs-only. README and `docs/release.md` smoke-test now show the explicit `--cask` (macOS) and `--formula` (Linux) forms. Verified working on macOS Tahoe 26.3:

```
$ brew install --cask nvidia/holodeck/holodeck
==> Installing Cask holodeck
==> Linking Binary 'holodeck' to '/opt/homebrew/bin/holodeck'
🍺  holodeck was successfully installed!
$ holodeck --version
holodeck version 0.3.6
```

## Follow-up (separate effort)

Dropping the Linux Formula entirely in favor of nfpms-built deb/rpm will eliminate the name collision and let plain `brew install <tap>/holodeck` work on macOS without the `--cask` flag. Tracked in a separate handoff.